### PR TITLE
Changed back to original LXD data for star HD038087

### DIFF
--- a/DAT_files/hd038087.dat
+++ b/DAT_files/hd038087.dat
@@ -22,4 +22,4 @@ WISE3 = 7.145 +/- 0.034
 # WISE4 = 1.994 +/- 0.020
 corfac_spex_SXD = 0.848
 LXD_man = True
-corfac_spex_LXD = 0.315
+corfac_spex_LXD = 0.75


### PR DESCRIPTION
This was actually still part of the previous pull request #9.
I changed back to the original LXD data for star HD038087 (from Feb 4 2007), because they look better than the "new" data (from Feb 6 2007).