### PR TITLE
Spectral type updates

### DIFF
--- a/DAT_files/bd+56d524.dat
+++ b/DAT_files/bd+56d524.dat
@@ -17,8 +17,8 @@ WISE1 = 8.935 +/- 0.023 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 8.953 +/- 0.021
 WISE3 = 8.996 +/- 0.031
 WISE4 = 8.592 +/- 0.335
-sptype = B1V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B0.5V
+sptype = B1V ; sptype ref = Johnson & Morgan 1955 (1955ApJ...122..429J)
+uvsptype = B0.5V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 0.984
 LXD_man = True
 corfac_spex_LXD = .98

--- a/DAT_files/hd003360.dat
+++ b/DAT_files/hd003360.dat
@@ -7,7 +7,7 @@ I = 3.95 +/- 0.03
 J = 4.135 +/- 0.300 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 4.248 +/- 0.254
 K = 4.247 +/- 0.036
-sptype = B2IV ; sptype ref = Morgan & Keenan 1973 (1973ARA&A..11...29M)
+sptype = B2IV ; sptype ref = Lesh 1968 (1968ApJS...17..371L)
 SpeX_SXD = SpeX_Data/hd003360_sxd_spex.fits
 SpeX_LXD = SpeX_Data/hd003360_lxd_spex.fits
 WISE1 = 4.299 +/- 0.305 ; WISE ref = IRSA AllWISE Source Catalog
@@ -17,3 +17,4 @@ WISE4 = 4.270 +/- 0.023
 corfac_spex_SXD = 1.199
 LXD_man = True
 corfac_spex_LXD = 1.115
+spex_mask = [(1.347,1.42),(1.798,1.942),(2.529,2.86)]

--- a/DAT_files/hd013338.dat
+++ b/DAT_files/hd013338.dat
@@ -8,8 +8,8 @@ K = 8.538 +/- 0.021
 IUE = IUE_Data/hd013338_iue.fits
 SpeX_SXD = SpeX_Data/hd013338_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd013338_LXD_spex.fits 
-sptype = B1V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B1.5V
+sptype = B1V ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
+uvsptype = B1.5V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 WISE1 = 8.493 +/- 0.023 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 8.536 +/- 0.020
 WISE3 = 8.576 +/- 0.024
@@ -17,3 +17,4 @@ WISE4 = 8.981 +/- 0.452
 corfac_spex_SXD = 0.845
 LXD_man = True
 corfac_spex_LXD = 3.25
+spex_mask = [(3.8,4.02)]

--- a/DAT_files/hd014250.dat
+++ b/DAT_files/hd014250.dat
@@ -17,8 +17,9 @@ WISE1 = 7.970 +/- 0.167 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 8.258 +/- 0.021
 WISE3 = 8.299 +/- 0.024
 WISE4 = 7.883 +/- 0.153
-sptype = B1IV ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B1.5III
+sptype = B0.5V:n ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
+uvsptype = B1.5III ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 0.152
 LXD_man = True
 corfac_spex_LXD = 0.93
+spex_mask = [(4.6,4.7)]

--- a/DAT_files/hd014422.dat
+++ b/DAT_files/hd014422.dat
@@ -11,8 +11,8 @@ SpeX_SXD = SpeX_Data/hd014422_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd014422_LXD_spex.fits
 # all Spitzer too high by 2 mags (wrong star?)
 # IRS = IRS_Data/hd014422_irs.fits
-sptype = B1V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B0.5IV
+sptype = B1V:pe ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
+uvsptype = B0.5IV ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 # MIPS24 = 3.30E+01 +/- 9.73E-01 mJy
 # IRAC1 = 6.72E+02 +/- 1.35E+01 mJy
 # IRAC2 = 5.09E+02 +/- 1.02E+01 mJy

--- a/DAT_files/hd014956.dat
+++ b/DAT_files/hd014956.dat
@@ -12,8 +12,8 @@ IUE = IUE_Data/hd014956_iue.fits
 SpeX_SXD = SpeX_Data/hd014956_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd014956_LXD_spex.fits
 IRS = IRS_Data/hd014956_irs.fits
-sptype = B2Ia ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B2Ib
+sptype = B2Ia ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
+uvsptype = B2Ib ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 MIPS24 = 8.28E+01 +/- 1.89E+00 mJy
 IRAC1 = 2.32E+03 +/- 4.65E+01 mJy
 IRAC2 = 1.59E+03 +/- 3.20E+01 mJy
@@ -30,3 +30,5 @@ WISE4 = 4.868 +/- 0.031
 corfac_spex_SXD = 0.898
 LXD_man = True
 corfac_spex_LXD = .88
+spex_mask = [(4.79,5.08)]
+

--- a/DAT_files/hd017505.dat
+++ b/DAT_files/hd017505.dat
@@ -16,8 +16,8 @@ WISE1 = 5.894 +/- 0.103 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 6.003 +/- 0.031
 WISE3 = 6.155 +/- 0.015
 WISE4 = 5.805 +/- 0.090
-sptype = O6V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = O5V
+sptype = O6.5III((f))n+O8V ; sptype ref = Sota+2011 (2011ApJS..193...24S)
+uvsptype = O5V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 0.750
 LXD_man = True
 corfac_spex_LXD = 1.43

--- a/DAT_files/hd029309.dat
+++ b/DAT_files/hd029309.dat
@@ -9,8 +9,8 @@ IUE = IUE_Data/hd029309_iue.fits
 SpeX_SXD = SpeX_Data/hd029309_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd029309_LXD_spex.fits
 IRS = IRS_Data/hd029309_irs.fits
-sptype = B2V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B2V
+sptype = B2V ; sptype ref = Guetter 1968 (1968PASP...80..197G)
+uvsptype = B2V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 MIPS24 = 3.54E+01 +/- 8.41E-01 mJy
 IRAC1 = 1.24E+03 +/- 2.50E+01 mJy
 IRAC2 = 8.06E+02 +/- 1.64E+01 mJy

--- a/DAT_files/hd029647.dat
+++ b/DAT_files/hd029647.dat
@@ -10,8 +10,8 @@ K = 5.363 +/- 0.020
 IUE = IUE_Data/hd029647_iue.fits
 SpeX_SXD = SpeX_Data/hd029647_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd029647_LXD_spex.fits
-sptype = B8III ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B8III
+sptype = B8III ; sptype ref = Metreveli 1969 (1969AbaOB..38...93M)
+uvsptype = B8III ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 IRS = IRS_Data/hd029647_irs.fits
 MIPS24 = 6.76E+01 +/- 1.89E+00 mJy
 IRAC1 = 2.23E+03 +/- 4.45E+01 mJy

--- a/DAT_files/hd032630.dat
+++ b/DAT_files/hd032630.dat
@@ -11,7 +11,7 @@ K = 3.70 +/- 0.03
 L = 3.77 +/- 0.03 ; L ref = 1984A&A...132..151L (source 1641 in appendix)
 IUE = IUE_Data/hd032630_iue.fits
 SpeX_SXD = SpeX_Data/hd032630_sxd_spex.fits
-sptype = B3V ; sptype ref = Morgan & Keenan 1973 (1973ARA&A..11...29M)
+sptype = B3V ; sptype ref = Lesh 1968 (1968ApJS...17..371L)
 WISE1 = 3.742 +/- 0.346 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 3.421 +/- 0.204
 WISE3 = 3.816 +/- 0.014

--- a/DAT_files/hd034759.dat
+++ b/DAT_files/hd034759.dat
@@ -8,7 +8,7 @@ K = 5.581 +/- 0.016
 IUE = IUE_Data/hd034759_iue.fits
 SpeX_SXD = SpeX_Data/hd034759_sxd_spex.fits
 SpeX_LXD = SpeX_Data/hd034759_lxd_spex.fits
-sptype = B5V ; sptype ref = Morgan & Keenan 1973 (1973ARA&A..11...29M)
+sptype = B5V ; sptype ref = Lesh 1968 (1968ApJS...17..371L)
 WISE1 = 5.717 +/- 0.139 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 5.555 +/- 0.053
 WISE3 = 5.724 +/- 0.015

--- a/DAT_files/hd034921.dat
+++ b/DAT_files/hd034921.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 34921
-V = 7.51 +/- 0.010    ;  UBV ref = 1956ApJS....2..389H
+V = 7.51 +/- 0.010 ; UBV ref = 1956ApJS....2..389H
 (B-V) = 0.14 +/- 0.010
 (U-B) = -0.86 +/- 0.010
 J = 6.696 +/- 0.019 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
@@ -9,8 +9,8 @@ IUE = IUE_Data/hd034921_iue.fits
 SpeX_SXD = SpeX_Data/hd034921_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd034921_LXD_spex.fits
 IRS = IRS_Data/hd034921_irs.fits
-sptype = B0IV ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B2III
+sptype = B0IVpe ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
+uvsptype = B2III ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 MIPS24 = 1.62E+02 +/- 3.53E+00 mJy
 IRAC1 = 1.36E+03 +/- 2.72E+01 mJy
 IRAC2 = 1.03E+03 +/- 2.09E+01 mJy

--- a/DAT_files/hd036512.dat
+++ b/DAT_files/hd036512.dat
@@ -10,7 +10,7 @@ K = 5.376 +/- 0.023
 L = 5.65 +/- 0.02 ; L ref = 1966CoLPL...4...99J (source 1855 in table 2)
 IUE = IUE_Data/hd036512_iue.fits
 SpeX_SXD = SpeX_Data/hd036512_sxd_spex.fits
-sptype = B0V ; sptype ref = Walborn 1971 (1971ApJS...23..257W)
+sptype = B0V ; sptype ref = Lesh 1968 (1968ApJS...17..371L)
 dered_RV = 3.1
 dered_AV = 0.12
 dered_FM = -0.24  0.74  3.56  0.52  4.59  1.00

--- a/DAT_files/hd037020.dat
+++ b/DAT_files/hd037020.dat
@@ -9,8 +9,8 @@ K = 5.668 +/- 0.021
 IUE = IUE_Data/hd037020_iue.fits
 SpeX_SXD = SpeX_Data/hd037020_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd037020_LXD_spex.fits
-sptype = B0.5V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B0.5V
+sptype = O8Vn ; sptype ref = Guetter 1968 (1968PASP...80..197G)
+uvsptype = B0.5V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 1.704
 LXD_man = True
 corfac_spex_LXD = 1.69

--- a/DAT_files/hd037022.dat
+++ b/DAT_files/hd037022.dat
@@ -9,8 +9,8 @@ K = 4.403 +/- 0.023
 IUE = IUE_Data/hd037022_iue.fits
 SpeX_SXD = SpeX_Data/hd037022_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd037022_LXD_spex.fits
-sptype = O6V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = O7V
+sptype = O7Vp ; sptype ref = Sota+2011 (2011ApJS..193...24S)
+uvsptype = O7V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 0.913
 LXD_man = True
 corfac_spex_LXD = 0.86

--- a/DAT_files/hd037023.dat
+++ b/DAT_files/hd037023.dat
@@ -14,4 +14,3 @@ uvsptype = B0.5V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 0.954
 LXD_man = True
 corfac_spex_LXD = 1.2
-#spex_mask = [(2.8,4.02)]

--- a/DAT_files/hd037023.dat
+++ b/DAT_files/hd037023.dat
@@ -9,8 +9,9 @@ K = 5.751 +/- 0.027
 IUE = IUE_Data/hd037023_iue.fits
 SpeX_SXD = SpeX_Data/hd037023_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd037023_LXD_spex.fits
-sptype = B0.5V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B0.5V
+sptype = B1.5Vp ; sptype ref = Levenhagen & Leister 2006 (2006MNRAS.371..252L)
+uvsptype = B0.5V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 0.954
 LXD_man = True
 corfac_spex_LXD = 1.2
+#spex_mask = [(2.8,4.02)]

--- a/DAT_files/hd037061.dat
+++ b/DAT_files/hd037061.dat
@@ -8,8 +8,8 @@ K = 5.490 +/- 0.021
 IUE = IUE_Data/hd037061_iue.fits
 SpeX_SXD = SpeX_Data/hd037061_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd037061_LXD_spex.fits
-sptype = B1V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B0V
+sptype = B1V ; sptype ref = Sharpless 1952 (1952ApJ...116..251S)
+uvsptype = B0V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 # There seems to be a problem with the WISE data, probably wrong source.
 # WISE1 = 8.407 +/- 0.249 ; WISE ref = IRSA AllWISE Source Catalog
 # WISE2 = 6.755 +/- 0.117

--- a/DAT_files/hd038087.dat
+++ b/DAT_files/hd038087.dat
@@ -10,8 +10,8 @@ IUE = IUE_Data/hd038087_iue.fits
 FUSE = FUSE_Data/hd038087_fuse.fits
 SpeX_SXD = SpeX_Data/hd038087_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd038087_LXD_spex.fits
-sptype = B5V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B4V
+sptype = B3II ; sptype ref = Houk & Swift 1999 (1999MSS...C05....0H)
+uvsptype = B4V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 IRAC3 = 1.4440E+02 +/- 7.0390E-02 mJy ; IRAC ref = IRSA SEIP Source List
 IRAC4 = 8.1580E+01 +/- 3.3750E-02 mJy
 # IRSA catalog flags W1, W2 and W4 as contaminated by scattered light halo.

--- a/DAT_files/hd051283.dat
+++ b/DAT_files/hd051283.dat
@@ -10,7 +10,7 @@ K = 5.680 +/- 0.020
 IUE = IUE_Data/hd051283_iue.fits
 SpeX_SXD = SpeX_Data/hd051283_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd051283_LXD_spex.fits
-sptype = B2III ; sptype ref = Hiltner 1969 (1969ApJ...157..313H)
+sptype = B2/3III ; sptype ref = Houk & Smith-Moore 1988 (1988MSS...C04....0H)
 dered_RV = 3.1
 dered_AV = 0.16
 dered_FM = -0.24  0.74  3.40  0.52  4.59  1.00

--- a/DAT_files/hd052721.dat
+++ b/DAT_files/hd052721.dat
@@ -8,8 +8,8 @@ K = 6.038 +/- 0.021
 IUE = IUE_Data/hd052721_iue.fits
 SpeX_SXD = SpeX_Data/hd052721_SXD_spex.fits
 #SpeX_LXD = SpeX_Data/hd052721_LXD_spex.fits
-sptype = B2V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B1V
+sptype = B2Vne ; sptype ref = Guetter 1968 (1968PASP...80..197G)
+uvsptype = B1V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 WISE1 = 6.040 +/- 0.074 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 5.631 +/- 0.042
 WISE3 = 5.071 +/- 0.025

--- a/DAT_files/hd156247.dat
+++ b/DAT_files/hd156247.dat
@@ -12,8 +12,8 @@ WISE1 = 5.923 +/- 0.108 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 5.793 +/- 0.044
 WISE3 = 5.935 +/- 0.015
 WISE4 = 5.700 +/- 0.041
-sptype = B5V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B4IV
+sptype = B3V ; sptype ref = Houk & Swift 1999 (1999MSS...C05....0H)
+uvsptype = B4IV ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 1.377
 LXD_man = True
 corfac_spex_LXD = 0.054

--- a/DAT_files/hd164794.dat
+++ b/DAT_files/hd164794.dat
@@ -10,7 +10,7 @@ K = 5.731 +/- 0.024
 IUE = IUE_Data/hd164794_iue.fits
 SpeX_SXD = SpeX_Data/hd164794_sxd_spex.fits
 SpeX_LXD = SpeX_Data/hd164794_lxd_spex.fits
-sptype = O4V((f)) ; sptype ref = Aidelman+2018 (2018A&A...610A..30A)
+sptype = O4V((f))z ; sptype ref = Sota+2014 (2014ApJS..211...10S)
 dered_RV = 3.1
 dered_AV = 0.85
 dered_FM = -0.24  0.74  4.0  0.25  4.59  1.00

--- a/DAT_files/hd166734.dat
+++ b/DAT_files/hd166734.dat
@@ -1,13 +1,13 @@
 # data file for observations of HD 166734
-V = 8.420 +/- 0.01  ; UBV ref = 1956ApJS....2..389
+V = 8.420 +/- 0.01 ; UBV ref = 1956ApJS....2..389
 (B-V) = 1.09 +/- 0.01
 (U-B) = -0.12 +/- 0.01
 J = 5.881 +/- 0.020 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 5.517 +/- 0.020
 K = 5.316 +/- 0.018
 IUE = IUE_Data/hd166734_iue.fits
-sptype = O8V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = O9.5Ia
+sptype = O7.5Iabf ; sptype ref = Sota+2011 (2011ApJS..193...24S)
+uvsptype = O9.5Ia ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 SpeX_SXD = SpeX_Data/hd166734_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd166734_LXD_spex.fits
 IRS = IRS_Data/hd166734_irs.fits
@@ -25,4 +25,4 @@ WISE4 = 4.174 +/- 0.032
 # corfac_irs_slope = 0.004
 # corfac_irs_zerowave = 7.480
 corfac_spex_SXD = 1.194
-corfac_spex_LXD = 2.209
+corfac_spex_LXD = 2.279

--- a/DAT_files/hd183143.dat
+++ b/DAT_files/hd183143.dat
@@ -17,4 +17,3 @@ sptype = B7Ia ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
 corfac_spex_SXD = 0.593
 LXD_man = True
 corfac_spex_LXD = 0.62
-#spex_mask = [(1.347,1.411),(1.801,1.942),(2.546,2.86),(4.176,4.583)]

--- a/DAT_files/hd183143.dat
+++ b/DAT_files/hd183143.dat
@@ -13,7 +13,8 @@ WISE1 = 3.307 +/- 0.478 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 2.817 +/- 0.483
 WISE3 = 3.053 +/- 0.012
 WISE4 = 2.768 +/- 0.021
-sptype = B7Iae ; sptype ref = Hobbs+2009 (2009ApJ...705...32H)
+sptype = B7Ia ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
 corfac_spex_SXD = 0.593
 LXD_man = True
 corfac_spex_LXD = 0.62
+#spex_mask = [(1.347,1.411),(1.801,1.942),(2.546,2.86),(4.176,4.583)]

--- a/DAT_files/hd185418.dat
+++ b/DAT_files/hd185418.dat
@@ -13,8 +13,9 @@ WISE1 = 7.007 +/- 0.041 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 7.126 +/- 0.019
 WISE3 = 7.249 +/- 0.019
 WISE4 = 7.477 +/- 0.139 
-sptype = B0.5V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B0.5III
+sptype = B0.5V ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
+uvsptype = B0.5III ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 1.002
 LXD_man = True
 corfac_spex_LXD = 0.79
+spex_mask = [(3.55,4.02)]

--- a/DAT_files/hd188209.dat
+++ b/DAT_files/hd188209.dat
@@ -34,4 +34,3 @@ corfac_irs = 0.95
 corfac_spex_SXD = 0.603
 LXD_man = True
 corfac_spex_LXD = 1.015
-#spex_mask = [(1.341,1.423),(1.799,1.926),(2.528,2.86),(4.182,4.563)]

--- a/DAT_files/hd188209.dat
+++ b/DAT_files/hd188209.dat
@@ -13,7 +13,7 @@ IUE = IUE_Data/hd188209_iue.fits
 SpeX_SXD = SpeX_Data/hd188209_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd188209_LXD_spex.fits
 IRS = IRS_Data/hd188209_irs.fits
-sptype = O9.5Iab ; sptype ref = Sota+2011 (2011ApJS..193...24S)
+sptype = O9.5Ia ; sptype ref = Lesh 1968 (1968ApJS...17..371L)
 dered_FM = -0.65  0.90  3.20  0.49  4.59  1.00
 dered_RV = 3.1
 dered_AV = 0.59
@@ -34,3 +34,4 @@ corfac_irs = 0.95
 corfac_spex_SXD = 0.603
 LXD_man = True
 corfac_spex_LXD = 1.015
+#spex_mask = [(1.341,1.423),(1.799,1.926),(2.528,2.86),(4.182,4.563)]

--- a/DAT_files/hd192660.dat
+++ b/DAT_files/hd192660.dat
@@ -14,8 +14,8 @@ IUE = IUE_Data/hd192660_iue.fits
 SpeX_SXD = SpeX_Data/hd192660_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd192660_LXD_spex.fits
 IRS = IRS_Data/hd192660_irs.fits
-sptype = B0Ia ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B0Ia
+sptype = B0Ia ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
+uvsptype = B0Ia ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_irs_maxwave = 32.0
 MIPS24 = 4.77E+01 +/- 1.07E+00 mJy
 IRAC1 = 1.38E+03 +/- 2.78E+01 mJy

--- a/DAT_files/hd204172.dat
+++ b/DAT_files/hd204172.dat
@@ -9,7 +9,7 @@ IUE = IUE_Data/hd204172_iue.fits
 SpeX_SXD = SpeX_Data/hd204172_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd204172_LXD_spex.fits
 IRS = IRS_Data/hd204172_irs.fits
-sptype = B0Ib ; sptype ref = Lutz&Lutz 1977 (1977AJ.....82..431L)
+sptype = B0Ib ; sptype ref = Lesh 1968 (1968ApJS...17..371L)
 dered_FM = -1.70  1.25  2.00  0.60  4.59  0.80
 dered_RV = 3.1
 dered_AV = 0.47

--- a/DAT_files/hd204827.dat
+++ b/DAT_files/hd204827.dat
@@ -12,8 +12,8 @@ SpeX_LXD = SpeX_Data/hd204827_LXD_spex.fits
 # OPT = Blue_Data/hd204827_opt.fits
 STIS_Opt = STIS_Data/hd204827_stis_Opt.fits
 corfac_nir = 1.12
-sptype = B0V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B0V
+sptype = B0V ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
+uvsptype = B0V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_irs_maxwave = 30.0
 MIPS24 = 2.09E+01 +/- 4.98E-01 mJy
 IRAC1 = 8.76E+02 +/- 1.77E+01 mJy

--- a/DAT_files/hd206773.dat
+++ b/DAT_files/hd206773.dat
@@ -10,8 +10,8 @@ FUSE = FUSE_Data/hd206773_fuse.fits
 SpeX_SXD = SpeX_Data/hd206773_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd206773_LXD_spex.fits
 IRS = IRS_Data/hd206773_irs.fits
-sptype = B0V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B0Ia
+sptype = B0V:pe ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
+uvsptype = B0Ia ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 MIPS24 = 1.23E+02 +/- 2.69E+00 mJy
 IRAC1 = 1.15E+03 +/- 2.32E+01 mJy
 IRAC2 = 8.30E+02 +/- 1.69E+01 mJy

--- a/DAT_files/hd214680.dat
+++ b/DAT_files/hd214680.dat
@@ -15,7 +15,7 @@ IRS = IRS_Data/hd214680_irs.fits
 SpeX_SXD = SpeX_Data/hd214680_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd214680_LXD_spex.fits
 corfac_nir = 0.85
-sptype = O9V ; sptype ref = Sota+2011 (2011ApJS..193...24S)
+sptype = O9V ; sptype ref = Lesh 1968 (1968ApJS...17..371L)
 dered_RV = 3.1
 dered_AV = 0.34
 dered_FM = -0.80  0.95  2.72  0.53  4.59  1.00

--- a/DAT_files/hd229238.dat
+++ b/DAT_files/hd229238.dat
@@ -9,8 +9,8 @@ IUE = IUE_Data/hd229238_iue.fits
 SpeX_SXD = SpeX_Data/hd229238_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd229238_LXD_spex.fits
 IRS = IRS_Data/hd229238_irs.fits
-sptype = B0Iab ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B0Ib
+sptype = B0Iab ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
+uvsptype = B0Ib ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_irs_maxwave = 32.0
 MIPS24 = 2.05E+01 +/- 5.12E-01 mJy
 IRAC1 = 6.18E+02 +/- 1.24E+01 mJy

--- a/DAT_files/hd283809.dat
+++ b/DAT_files/hd283809.dat
@@ -8,10 +8,8 @@ J = 6.994 +/- 0.020 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 6.461 +/- 0.033
 K = 6.169 +/- 0.023
 STIS = STIS_Data/hd283809_stis.fits
-# added to allow IUE comparison stars
-IUE = STIS_Data/hd283809_stis.fits
 IRS = IRS_Data/hd283809_irs.fits
-sptype = B3V ; sptype ref = Murakawa+2000 (2000ApJS..128..603M)
+sptype = B3V ; sptype ref = Murakawa, Tamura & Nagata 2000 (2000ApJS..128..603M)
 SpeX_SXD = SpeX_Data/hd283809_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd283809_LXD_spex.fits
 MIPS24 = 2.85E+01 +/- 8.05E-01 mJy
@@ -30,3 +28,4 @@ WISE4 = 5.880 +/- 0.052
 corfac_spex_SXD = 1.304
 LXD_man = True
 corfac_spex_LXD = 1.09
+#spex_mask = [(1.347,1.410),(1.801,1.928),(2.529,2.86),(4.186,4.559)]

--- a/DAT_files/hd283809.dat
+++ b/DAT_files/hd283809.dat
@@ -28,4 +28,3 @@ WISE4 = 5.880 +/- 0.052
 corfac_spex_SXD = 1.304
 LXD_man = True
 corfac_spex_LXD = 1.09
-#spex_mask = [(1.347,1.410),(1.801,1.928),(2.529,2.86),(4.186,4.559)]

--- a/DAT_files/hd294264.dat
+++ b/DAT_files/hd294264.dat
@@ -8,8 +8,8 @@ K = 7.582 +/- 0.033
 IUE = IUE_Data/hd294264_iue.fits
 SpeX_SXD = SpeX_Data/hd294264_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd294264_LXD_spex.fits
-sptype = B3V ; (uv)sptype ref = Valencic+2004 (2004ApJ...616..912V)
-uvsptype = B3IV
+sptype = B3 ; sptype ref = Nesterov+1995 (1995A&AS..110..367N)
+uvsptype = B3IV ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 IRAC3 = 1.3050E+02 +/- 6.3350E-02 mJy ; IRAC ref = IRSA SEIP Source List
 IRAC4 = 8.0270E+01 +/- 4.2560E-02 mJy
 WISE1 = 7.448 +/- 0.036 ; WISE ref = IRSA AllWISE Source Catalog

--- a/DAT_files/hd294264.dat
+++ b/DAT_files/hd294264.dat
@@ -8,7 +8,7 @@ K = 7.582 +/- 0.033
 IUE = IUE_Data/hd294264_iue.fits
 SpeX_SXD = SpeX_Data/hd294264_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd294264_LXD_spex.fits
-sptype = B3 ; sptype ref = Nesterov+1995 (1995A&AS..110..367N)
+sptype = B3V ; sptype ref = Valencic+2004 (2004ApJ...616..912V)
 uvsptype = B3IV ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 IRAC3 = 1.3050E+02 +/- 6.3350E-02 mJy ; IRAC ref = IRSA SEIP Source List
 IRAC4 = 8.0270E+01 +/- 4.2560E-02 mJy


### PR DESCRIPTION
I have updated some spectral types and the references to the spectral types, to be consistent with what will be in the NIR extinction paper.
I also added masks for some stars to exclude bad wavelength regions in the SpeX spectra.