### PR TITLE
Photometry and spectral type references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.png
 *.fits
+*.DS_Store

--- a/DAT_files/bd+56d524.dat
+++ b/DAT_files/bd+56d524.dat
@@ -1,7 +1,7 @@
 # data file for observations of BD+56 524
-V = 9.750 +/- 0.010
-B = 10.090 +/- 0.010
-U = 9.600 +/- 0.010
+V = 9.75 +/- 0.01 ; UBV ref = Valencic+2004 (2004ApJ...616..912V)
+B = 10.09 +/- 0.01
+U = 9.60 +/- 0.01
 J = 9.043 +/- 0.032 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 8.998 +/- 0.032
 K = 8.974 +/- 0.020
@@ -9,7 +9,8 @@ IUE = IUE_Data/bd+56d524_iue.fits
 FUSE = FUSE_Data/bd+56d524_fuse.fits
 SpeX_SXD = SpeX_Data/bd+56d524_SXD_spex.fits
 SpeX_LXD = SpeX_Data/bd+56d524_LXD_spex.fits
-IRAC1 = 6.2230E+01 +/- 1.3140E-02 mJy ; IRAC ref = IRSA SEIP Source List
+# IRAC 1 seems off
+# IRAC1 = 6.2230E+01 +/- 1.3140E-02 mJy ; IRAC ref = IRSA SEIP Source List
 IRAC2 = 4.4420E+01 +/- 1.2150E-02 mJy
 IRAC3 = 2.7870E+01 +/- 1.9910E-02 mJy
 IRAC4 = 1.4820E+01 +/- 1.0560E-02 mJy
@@ -17,8 +18,9 @@ WISE1 = 8.935 +/- 0.023 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 8.953 +/- 0.021
 WISE3 = 8.996 +/- 0.031
 WISE4 = 8.592 +/- 0.335
-sptype = B1V ; sptype ref = Johnson & Morgan 1955 (1955ApJ...122..429J)
+sptype = B1V ; sptype ref = Borgman 1960 (1960BAN....15..255B)
 uvsptype = B0.5V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 0.984
 LXD_man = True
-corfac_spex_LXD = .98
+corfac_spex_LXD = 0.99
+spex_mask = [(1.343,1.36),(1.802,1.949),(2.5,2.903),(4.011,4.02)]

--- a/DAT_files/hd003360.dat
+++ b/DAT_files/hd003360.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 3360
-U = 2.58 +/- 0.03 ; UBVRI ref = 2002yCat.2237....0D (no uncertainties, assume 0.03)
+U = 2.58 +/- 0.03 ; UBVRI ref = Johnson+1966 (1966CoLPL...4...99J, source 153)
 B = 3.47 +/- 0.03
 V = 3.66 +/- 0.03
 R = 3.74 +/- 0.03
@@ -17,4 +17,4 @@ WISE4 = 4.270 +/- 0.023
 corfac_spex_SXD = 1.199
 LXD_man = True
 corfac_spex_LXD = 1.115
-spex_mask = [(1.347,1.42),(1.798,1.942),(2.529,2.86)]
+spex_mask = [(1.346,1.452),(1.798,1.965),(2.514,2.88)]

--- a/DAT_files/hd013338.dat
+++ b/DAT_files/hd013338.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 13338
-V = 9.030 +/- 0.010
-B = 9.270 +/- 0.010
-U = 8.720 +/- 0.010
+V = 9.03 +/- 0.01 ; UBV ref = Valencic+2004 (2004ApJ...616..912V)
+B = 9.27 +/- 0.01
+U = 8.72 +/- 0.01
 J = 8.546 +/- 0.030 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 8.501 +/- 0.030
 K = 8.538 +/- 0.021
@@ -16,5 +16,5 @@ WISE3 = 8.576 +/- 0.024
 WISE4 = 8.981 +/- 0.452
 corfac_spex_SXD = 0.845
 LXD_man = True
-corfac_spex_LXD = 3.25
-spex_mask = [(3.8,4.02)]
+corfac_spex_LXD = 3.2
+spex_mask = [(1.343,1.453),(1.796,1.949),(2.494,2.51),(3.8,4.02)]

--- a/DAT_files/hd014250.dat
+++ b/DAT_files/hd014250.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 14250
-V = 8.960 +/- 0.010
-B = 9.280 +/- 0.010
-U = 8.740 +/- 0.010
+V = 8.96 +/- 0.01 ; UBV ref = Valencic+2004 (2004ApJ...616..912V)
+B = 9.28 +/- 0.01
+U = 8.74 +/- 0.01
 J = 8.274 +/- 0.030 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 8.225 +/- 0.044
 K = 8.209 +/- 0.029
@@ -9,11 +9,13 @@ IUE = IUE_Data/hd014250_iue.fits
 FUSE = FUSE_Data/hd014250_fuse.fits
 SpeX_SXD = SpeX_Data/hd014250_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd014250_LXD_spex.fits
-IRAC1 = 1.0280E+02 +/- 1.6860E-02 mJy ; IRAC ref = IRSA SEIP Source List
+# IRAC 1 seems off
+# IRAC1 = 1.0280E+02 +/- 1.6860E-02 mJy ; IRAC ref = IRSA SEIP Source List
 IRAC2 = 8.3720E+01 +/- 1.6640E-02 mJy
 IRAC3 = 5.8230E+01 +/- 2.8300E-02 mJy
 IRAC4 = 3.0410E+01 +/- 1.4140E-02 mJy
-WISE1 = 7.970 +/- 0.167 ; WISE ref = IRSA AllWISE Source Catalog
+# WISE 1 seems off
+# WISE1 = 7.970 +/- 0.167 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 8.258 +/- 0.021
 WISE3 = 8.299 +/- 0.024
 WISE4 = 7.883 +/- 0.153
@@ -22,4 +24,4 @@ uvsptype = B1.5III ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 0.152
 LXD_man = True
 corfac_spex_LXD = 0.93
-spex_mask = [(4.6,4.7)]
+spex_mask = [(1.347,1.36),(1.8,1.954),(2.514,2.885),(4.6,4.7)]

--- a/DAT_files/hd014422.dat
+++ b/DAT_files/hd014422.dat
@@ -1,11 +1,11 @@
 # data file for observations of HD 14422
-V = 9.03 +/- 0.006 ; UBV ref = 1955ApJ...122..429J
+V = 9.03 +/- 0.006 ; UBV ref = Johnson & Morgan 1955 (1955ApJ...122..429J, star 2138)
 (B-V) = 0.50 +/- 0.005
 (U-B) = -0.65 +/- 0.010
 J = 8.359 +/- 0.026 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 8.211 +/- 0.049
 K = 8.081 +/- 0.027
-L = 7.82 +/- 0.13   ; L ref = 1974ApJ...190...73S
+L = 7.82 +/- 0.13 ; L ref = 1974ApJ...190...73S
 IUE = IUE_Data/hd014422_iue.fits
 SpeX_SXD = SpeX_Data/hd014422_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd014422_LXD_spex.fits
@@ -29,4 +29,5 @@ uvsptype = B0.5IV ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 # corfac_irs_zerowave = 7.535
 corfac_spex_SXD = 0.281
 LXD_man = True
-corfac_spex_LXD = .355
+corfac_spex_LXD = 0.36
+spex_mask = [(1.8,1.82),(2.86,2.926)]

--- a/DAT_files/hd014956.dat
+++ b/DAT_files/hd014956.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 14956
-V = 7.19  +/- 0.020  ; UBVRI ref = 1967BOTT....4..149M
+V = 7.19 +/- 0.020 ; UBVRI ref = Mendoza 1967 (1967BOTT....4..149M)
 (B-V) = 0.72 +/- 0.020
 (U-B) = -0.29 +/- 0.020
 (V-R) = 0.65 +/- 0.02
@@ -29,6 +29,5 @@ WISE4 = 4.868 +/- 0.031
 # corfac_irs_zerowave = 7.474
 corfac_spex_SXD = 0.898
 LXD_man = True
-corfac_spex_LXD = .88
-spex_mask = [(4.79,5.08)]
-
+corfac_spex_LXD = 0.88
+spex_mask = [(1.347,1.36),(1.798,1.81),(2.508,2.909),(4.814,4.82)]

--- a/DAT_files/hd017505.dat
+++ b/DAT_files/hd017505.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 17505
-V = 7.060 +/- 0.010
-B = 7.460 +/- 0.010
-U = 6.820 +/- 0.010
+V = 7.06 +/- 0.01 ; UBV ref = Valencic+2004 (2004ApJ...616..912V)
+B = 7.46 +/- 0.01
+U = 6.82 +/- 0.01
 J = 6.286 +/- 0.034 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 6.177 +/- 0.055
 K = 6.159 +/- 0.020
@@ -12,12 +12,14 @@ SpeX_LXD = SpeX_Data/hd017505_LXD_spex.fits
 IRAC1 = 9.5880E+02 +/- 4.7290E-02 mJy ; IRAC ref = IRSA SEIP Source List
 IRAC2 = 5.6670E+02 +/- 4.0890E-02 mJy
 IRAC4 = 2.3330E+02 +/- 3.2110E-02 mJy
-WISE1 = 5.894 +/- 0.103 ; WISE ref = IRSA AllWISE Source Catalog
-WISE2 = 6.003 +/- 0.031
+# WISE 1 and 2 seem off
+# WISE1 = 5.894 +/- 0.103 ; WISE ref = IRSA AllWISE Source Catalog
+# WISE2 = 6.003 +/- 0.031
 WISE3 = 6.155 +/- 0.015
 WISE4 = 5.805 +/- 0.090
 sptype = O6.5III((f))n+O8V ; sptype ref = Sota+2011 (2011ApJS..193...24S)
 uvsptype = O5V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 0.750
 LXD_man = True
-corfac_spex_LXD = 1.43
+corfac_spex_LXD = 1.44
+spex_mask = [(0.804,0.805),(1.346,1.415),(4,4.02),(4.98,5.07)]

--- a/DAT_files/hd029309.dat
+++ b/DAT_files/hd029309.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 29309
-V = 7.10 +/- 0.010     ; UBV ref = 1974PASP...86..795G
+V = 7.10 +/- 0.010 ; UBV ref = Guetter 1974 (1974PASP...86..795G)
 (B-V) = 0.32 +/- 0.010
 (U-B) = -0.31 +/- 0.010
 J = 6.122 +/- 0.020 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
@@ -27,3 +27,4 @@ WISE4 = 5.636 +/- 0.043
 corfac_spex_SXD = 1.001
 LXD_man = True
 corfac_spex_LXD = 0.94
+spex_mask = [(0.805,0.8062),(1.35,1.36),(1.94,1.951),(2.516,2.89),(4,4.02)]

--- a/DAT_files/hd029647.dat
+++ b/DAT_files/hd029647.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 29647
-V = 8.31 +/- 0.017  ; UBVRI ref = 1980SvAL....6..397S
+V = 8.31 +/- 0.017 ; UBVRI ref = Slutskij, Stalbovskij & Shevchenko 1980 (1980SvAL....6..397S)
 (U-B) = 0.47 +/- 0.030
 (B-V) = 0.91 +/- 0.019
 (V-R) = 0.96 +/- 0.024
@@ -10,20 +10,23 @@ K = 5.363 +/- 0.020
 IUE = IUE_Data/hd029647_iue.fits
 SpeX_SXD = SpeX_Data/hd029647_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd029647_LXD_spex.fits
-sptype = B8III ; sptype ref = Metreveli 1969 (1969AbaOB..38...93M)
+sptype = B7IV ; sptype ref = Murakawa, Tamura & Nagata 2000 (2000ApJS..128..603M)
 uvsptype = B8III ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 IRS = IRS_Data/hd029647_irs.fits
 MIPS24 = 6.76E+01 +/- 1.89E+00 mJy
-IRAC1 = 2.23E+03 +/- 4.45E+01 mJy
-IRAC2 = 1.50E+03 +/- 3.00E+01 mJy
+# IRAC 1 and 2 seem off
+# IRAC1 = 2.23E+03 +/- 4.45E+01 mJy
+# IRAC2 = 1.50E+03 +/- 3.00E+01 mJy
 IRAC3 = 1.06E+03 +/- 2.16E+01 mJy
 IRAC4 = 5.42E+02 +/- 1.09E+01 mJy
 IRS15 = 3.14E+02 +/- 6.51E+00 mJy
-WISE1 = 5.179 +/- 0.150 ; WISE ref = IRSA AllWISE Source Catalog
-WISE2 = 4.905 +/- 0.068
+# WISE 1 and 2 seem off
+# WISE1 = 5.179 +/- 0.150 ; WISE ref = IRSA AllWISE Source Catalog
+# WISE2 = 4.905 +/- 0.068
 WISE3 = 4.882 +/- 0.023
 WISE4 = 3.821 +/- 0.033
 # corfac_irs = 0.990
 corfac_spex_SXD = 1.254
 LXD_man = True
 corfac_spex_LXD = 1.1
+spex_mask = [(1.94,1.95),(2.87,2.88),(4.006,4.02),(5.32,5.41)]

--- a/DAT_files/hd031726.dat
+++ b/DAT_files/hd031726.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 31726 (IUE standard)
-V = 6.147 +/- 0.001  ; UBV ref = 1983ApJS...52....7F
+V = 6.147 +/- 0.001 ; UBV ref = Menzies, Marang & Westerhuys 1990 (1990SAAOC..14...33M)
 (B-V) = -0.206 +/- 0.002
 (U-B) = -0.873 +/- 0.004
 J = 6.642 +/- 0.020 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
@@ -27,6 +27,7 @@ WISE4 = 6.904 +/- 0.083
 # corfac_irs = 0.916
 # corfac_irs_slope = 0.001
 # corfac_irs_zerowave = 7.465
-corfac_spex_SXD = 0.942
+corfac_spex_SXD = 0.943
 LXD_man = True
 corfac_spex_LXD = 0.95
+spex_mask = [(0.804,0.8054),(1.347,1.452),(1.794,1.951),(2.515,2.878)]

--- a/DAT_files/hd032630.dat
+++ b/DAT_files/hd032630.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 32630 (IUE standard)
-V = 3.18 +/- 0.02 ; UBVRI ref = 1966CoLPL...4...99J
+V = 3.18 +/- 0.02 ; UBVRI ref = Johnson+1966 (1966CoLPL...4...99J, source 1641)
 (B-V) = -0.18 +/- 0.02 
 (U-B) = -0.67 +/- 0.02 
 R = 3.23 +/- 0.02
@@ -21,3 +21,4 @@ dered_AV = 0.06
 dered_FM = -0.24  0.74  3.56  0.52  4.59  1.00
 corfac_spex_SXD = 1.085
 corfac_spex_LXD = None
+spex_mask = [(0.806,0.807),(1.343,1.447),(1.802,1.951)]

--- a/DAT_files/hd034759.dat
+++ b/DAT_files/hd034759.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 34759 (IUE standard)
-V = 5.22 +/- 0.019 ; UBVRI ref = 1971AJ.....76.1058C
+V = 5.22 +/- 0.019 ; UBV ref = Crawford, Barnes & Golson 1971 (1971AJ.....76.1058C)
 (B-V) = -0.14 +/- 0.010
 (U-B) = -0.57 +/- 0.015
 J = 5.437 +/- 0.019 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
@@ -19,3 +19,4 @@ dered_FM = -0.24  0.74  3.56  0.52  4.59  1.00
 corfac_spex_SXD = 0.937
 LXD_man = True
 corfac_spex_LXD = 1.0
+spex_mask = [(1.347,1.452),(1.78,1.961),(2.52,2.88),(5.24,5.34)]

--- a/DAT_files/hd034816.dat
+++ b/DAT_files/hd034816.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 34816 (IUE standard)
-V = 4.29 +/- 0.02  ; UBVRI ref = 1966CoLPL...4...99J
+V = 4.29 +/- 0.02 ; UBVRI ref = Johnson+1966 (1966CoLPL...4...99J, source 1756)
 (B-V) = -0.25 +/- 0.02
 (U-B) = -1.01 +/- 0.02
 R = 4.41 +/- 0.02
@@ -29,4 +29,5 @@ WISE4 = 5.200 +/- 0.033
 # corfac_irs_zerowave = 7.462
 corfac_spex_SXD = 0.902
 LXD_man = True
-corfac_spex_LXD = 0.893
+corfac_spex_LXD = 0.894
+spex_mask = [(0.807,0.809),(1.804,1.952),(2.514,2.903),(4.01,4.02)]

--- a/DAT_files/hd034921.dat
+++ b/DAT_files/hd034921.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 34921
-V = 7.51 +/- 0.010 ; UBV ref = 1956ApJS....2..389H
-(B-V) = 0.14 +/- 0.010
-(U-B) = -0.86 +/- 0.010
+V = 7.51 +/- 0.01 ; UBV ref = Hiltner 1956 (1956ApJS....2..389H)
+(B-V) = 0.14 +/- 0.01
+(U-B) = -0.86 +/- 0.01
 J = 6.696 +/- 0.019 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 6.507 +/- 0.016
 K = 6.230 +/- 0.017
@@ -13,12 +13,14 @@ sptype = B0IVpe ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M
 uvsptype = B2III ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 MIPS24 = 1.62E+02 +/- 3.53E+00 mJy
 IRAC1 = 1.36E+03 +/- 2.72E+01 mJy
-IRAC2 = 1.03E+03 +/- 2.09E+01 mJy
+# IRAC 2 seems off
+# IRAC2 = 1.03E+03 +/- 2.09E+01 mJy
 IRAC3 = 8.55E+02 +/- 1.90E+01 mJy
 IRAC4 = 5.63E+02 +/- 1.16E+01 mJy
 IRS15 = 3.12E+02 +/- 6.32E+00 mJy
-WISE1 = 5.636 +/- 0.164 ; WISE ref = IRSA AllWISE Source Catalog
-WISE2 = 5.157 +/- 0.079
+# WISE 1 and 2 seem off
+# WISE1 = 5.636 +/- 0.164 ; WISE ref = IRSA AllWISE Source Catalog
+# WISE2 = 5.157 +/- 0.079
 WISE3 = 4.491 +/- 0.015
 WISE4 = 3.385 +/- 0.025
 # corfac_irs = 0.995
@@ -27,3 +29,4 @@ WISE4 = 3.385 +/- 0.025
 corfac_spex_SXD = 1.101
 LXD_man = True
 corfac_spex_LXD = 1.13
+spex_mask = [(0.804,0.805),(2.87,2.88)]

--- a/DAT_files/hd036512.dat
+++ b/DAT_files/hd036512.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 36512 (IUE standard)
-V = 4.62 +/- 0.02 ; UBVRI ref = 1966CoLPL...4...99J
+V = 4.62 +/- 0.02 ; UBVRI ref = Johnson+1966 (1966CoLPL...4...99J, source 1855)
 (B-V) = -0.26 +/- 0.02
 (U-B) = -1.07 +/- 0.02
 R = 4.74 +/- 0.02
@@ -33,3 +33,4 @@ corfac_irs = 0.925
 # corfac_irs_zerowave = 7.465
 corfac_spex_SXD = 1.050
 corfac_spex_LXD = None
+spex_mask = [(1.347,1.421),(1.799,1.95)]

--- a/DAT_files/hd037020.dat
+++ b/DAT_files/hd037020.dat
@@ -1,9 +1,10 @@
 # data file for observations of HD 37020
-V = 6.720 +/- 0.010
-B = 6.720 +/- 0.010
-U = 5.840 +/- 0.010
-J = 6.140 +/- 0.040
-# 2MASS J seems to be wrong: J = 7.120
+V = 6.72 +/- 0.01 ; UBVJ ref = Valencic+2004 (2004ApJ...616..912V)
+B = 6.72 +/- 0.01
+U = 5.84 +/- 0.01
+J = 6.14 +/- 0.04
+# no detection in 2MASS J
+# 2MASS HK suffer from diffraction spike confusion
 H = 5.802 +/- 0.024 ; HK ref = IRSA 2MASS All-Sky Point Source Catalog
 K = 5.668 +/- 0.021
 IUE = IUE_Data/hd037020_iue.fits
@@ -14,3 +15,4 @@ uvsptype = B0.5V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 1.704
 LXD_man = True
 corfac_spex_LXD = 1.69
+spex_mask = [(0.803,0.8042),(1.796,1.952),(2.513,2.53),(4.005,4.02)]

--- a/DAT_files/hd037022.dat
+++ b/DAT_files/hd037022.dat
@@ -1,10 +1,11 @@
 # data file for observations of HD 37022
-V = 5.130 +/- 0.010
-B = 5.130 +/- 0.020
-U = 4.200 +/- 0.010
-J = 4.580 +/- 0.040
+V = 5.13 +/- 0.01 ; UBVJ ref = Valencic+2004 (2004ApJ...616..912V)
+B = 5.13 +/- 0.02
+U = 4.20 +/- 0.01
+J = 4.58 +/- 0.04
 # 2MASS J seems to be wrong: J = 1.802 +/- 0.938
-H = 4.629 +/- 0.036; HK ref = IRSA 2MASS All-Sky Point Source Catalog
+# 2MASS HK suffer from diffraction spike confusion
+H = 4.629 +/- 0.036 ; HK ref = IRSA 2MASS All-Sky Point Source Catalog
 K = 4.403 +/- 0.023
 IUE = IUE_Data/hd037022_iue.fits
 SpeX_SXD = SpeX_Data/hd037022_SXD_spex.fits
@@ -13,4 +14,5 @@ sptype = O7Vp ; sptype ref = Sota+2011 (2011ApJS..193...24S)
 uvsptype = O7V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 0.913
 LXD_man = True
-corfac_spex_LXD = 0.86
+corfac_spex_LXD = 0.863
+spex_mask = [(0.804,0.8054),(1.347,1.416),(1.94,1.953),(2.514,2.895)]

--- a/DAT_files/hd037023.dat
+++ b/DAT_files/hd037023.dat
@@ -1,16 +1,18 @@
 # data file for observations of HD 37023
-V = 6.690 +/- 0.010
-B = 6.770 +/- 0.010
-U = 5.960 +/- 0.020
-J = 6.060 +/- 0.040
-# 2MASS J seems to be wrong: J = 7.146
+V = 6.69 +/- 0.01 ; UBV ref = Valencic+2004 (2004ApJ...616..912V)
+B = 6.77 +/- 0.01
+U = 5.96 +/- 0.02
+J = 6.01 +/- 0.01 ; J ref = 2002ApJ...573..366M
+# no detection in 2MASS J
+# 2MASS HK suffer from diffraction spike confusion
 H = 5.891 +/- 0.053 ; HK ref = IRSA 2MASS All-Sky Point Source Catalog
 K = 5.751 +/- 0.027
 IUE = IUE_Data/hd037023_iue.fits
 SpeX_SXD = SpeX_Data/hd037023_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd037023_LXD_spex.fits
-sptype = B1.5Vp ; sptype ref = Levenhagen & Leister 2006 (2006MNRAS.371..252L)
+sptype = B0.5Vp ; sptype ref = Borgman 1960 (1960BAN....15..255B)
 uvsptype = B0.5V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
-corfac_spex_SXD = 0.954
+corfac_spex_SXD = 0.969
 LXD_man = True
-corfac_spex_LXD = 1.2
+corfac_spex_LXD = 1.215
+spex_mask = [(0.805,0.8055),(1.801,1.959),(2.512,2.881),(4.01,4.02)]

--- a/DAT_files/hd037061.dat
+++ b/DAT_files/hd037061.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 37061
-V = 6.830 +/- 0.010
-B = 7.090 +/- 0.010
-U = 6.400 +/- 0.010
+V = 6.83 +/- 0.01 ; UBV ref = Valencic+2004 (2004ApJ...616..912V)
+B = 7.09 +/- 0.01
+U = 6.40 +/- 0.01
 J = 5.752 +/- 0.027 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 5.588 +/- 0.040
 K = 5.490 +/- 0.021
@@ -15,4 +15,5 @@ uvsptype = B0V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 # WISE2 = 6.755 +/- 0.117
 corfac_spex_SXD = 1.007
 LXD_man = True
-corfac_spex_LXD = 0.98
+corfac_spex_LXD = 0.985
+spex_mask = [(0.805,0.8057),(1.343,1.42),(1.798,1.957),(2.87,2.883),(3.995,4.02)]

--- a/DAT_files/hd038087.dat
+++ b/DAT_files/hd038087.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 38087
-V = 8.300 +/- 0.010
-B = 8.420 +/- 0.010
-U = 7.970 +/- 0.010
+V = 8.30 +/- 0.01 ; UBV ref = Valencic+2004 (2004ApJ...616..912V)
+B = 8.42 +/- 0.01
+U = 7.97 +/- 0.01
 # IRSA (2MASS, IRAC and WISE) catalogs all refer to object IC435 when searching for this star. IC435 is the nebula surrounding this star.
 J = 7.588 +/- 0.024 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 7.386 +/- 0.042
@@ -23,3 +23,4 @@ WISE3 = 7.145 +/- 0.034
 corfac_spex_SXD = 0.848
 LXD_man = True
 corfac_spex_LXD = 0.75
+spex_mask = [(0.808,0.809),(1.343,1.42),(1.781,1.954),(2.517,2.891),(4.01,4.02)]

--- a/DAT_files/hd042560.dat
+++ b/DAT_files/hd042560.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 42560
-U = 3.65 +/- 0.03 ; UBVRI ref = 2002yCat.2237....0D (no uncertainties, assume 0.03)
+U = 3.65 +/- 0.03 ; UBVRI ref = Johnson+1966 (1966CoLPL...4...99J, source 2199)
 B = 4.31 +/- 0.03
 V = 4.48 +/- 0.03
 R = 4.53 +/- 0.03
@@ -17,3 +17,4 @@ WISE4 = 4.988 +/- 0.036
 corfac_spex_SXD = 0.762
 LXD_man = True
 corfac_spex_LXD = 1.57
+spex_mask = [(0.806,0.807),(1.4,1.415),(1.799,1.953),(2.514,2.88),(4,4.03)]

--- a/DAT_files/hd047839.dat
+++ b/DAT_files/hd047839.dat
@@ -1,9 +1,10 @@
 # data file for observations of HD 47839 (IUE standard)
-V = 4.66 +/- 0.02 ; UBVRI ref = 1966CoLPL...4...99J
+V = 4.66 +/- 0.02 ; UBVRI ref = Johnson+1966 (1966CoLPL...4...99J, source 2456)
 U = 3.35 +/- 0.02
 B = 4.42 +/- 0.02
 R = 4.77 +/- 0.02
 I = 4.99 +/- 0.02
+# 2MASS J suffers from diffraction spike confusion
 J = 5.202 +/- 0.023 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 5.322 +/- 0.021
 K = 5.340 +/- 0.021
@@ -28,3 +29,4 @@ WISE4 = 5.336 +/- 0.212
 # corfac_irs = 0.990
 corfac_spex_SXD = 0.994
 corfac_spex_LXD = None
+spex_mask = [(1.343,1.356),(1.94,1.95),(2.417,2.43)]

--- a/DAT_files/hd051283.dat
+++ b/DAT_files/hd051283.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 51283 (IUE standard)
-V = 5.32 +/- 0.023  ; UBVRI ref = 1983ApJS...52....7F
+V = 5.32 +/- 0.023 ; UBVRI ref = Fernie 1983 (1983ApJS...52....7F)
 (B-V) = -0.17 +/- 0.018
-(U-B) = -0.96 +/- 0.027
+(U-V) = -0.96 +/- 0.027
 (V-R) = -0.06 +/- 0.02
 (V-I) = -0.11 +/- 0.02
 J = 5.632 +/- 0.023 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
@@ -10,7 +10,7 @@ K = 5.680 +/- 0.020
 IUE = IUE_Data/hd051283_iue.fits
 SpeX_SXD = SpeX_Data/hd051283_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd051283_LXD_spex.fits
-sptype = B2/3III ; sptype ref = Houk & Smith-Moore 1988 (1988MSS...C04....0H)
+sptype = B3II-III ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
 dered_RV = 3.1
 dered_AV = 0.16
 dered_FM = -0.24  0.74  3.40  0.52  4.59  1.00
@@ -31,3 +31,4 @@ WISE4 = 5.176 +/- 0.032
 corfac_spex_SXD = 1.019
 LXD_man = True
 corfac_spex_LXD = 0.84
+spex_mask = [(1.347,1.36),(1.799,1.949),(2.514,2.98)]

--- a/DAT_files/hd052721.dat
+++ b/DAT_files/hd052721.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 52721
-V = 6.580 +/- 0.050
-B = 6.640 +/- 0.060
-U = 5.900 +/- 0.060
+V = 6.58 +/- 0.05 ; UBV ref = Valencic+2004 (2004ApJ...616..912V)
+B = 6.64 +/- 0.06
+U = 5.90 +/- 0.06
 J = 6.243 +/- 0.018 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 6.156 +/- 0.029
 K = 6.038 +/- 0.021
@@ -10,10 +10,12 @@ SpeX_SXD = SpeX_Data/hd052721_SXD_spex.fits
 #SpeX_LXD = SpeX_Data/hd052721_LXD_spex.fits
 sptype = B2Vne ; sptype ref = Guetter 1968 (1968PASP...80..197G)
 uvsptype = B1V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
-WISE1 = 6.040 +/- 0.074 ; WISE ref = IRSA AllWISE Source Catalog
-WISE2 = 5.631 +/- 0.042
+# WISE 1 and 2 seem off
+# WISE1 = 6.040 +/- 0.074 ; WISE ref = IRSA AllWISE Source Catalog
+# WISE2 = 5.631 +/- 0.042
 WISE3 = 5.071 +/- 0.025
 # Something seems to be wrong with the WISE4 value
 # WISE4 = 2.483 +/- 0.034
 corfac_spex_SXD = 0.949
 corfac_spex_LXD = None
+spex_mask = [(1.343,1.421),(1.799,1.82)]

--- a/DAT_files/hd078316.dat
+++ b/DAT_files/hd078316.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 78316
-U = 4.70 +/- 0.03 ; UBV ref = 2002yCat.2237....0D (no uncertainties, assume 0.03)
-B = 5.13 +/- 0.03
-V = 5.24 +/- 0.03
+U = 4.69 +/- 0.03 ; UBV ref = Abt & Golson 1962 (1962ApJ...136...35A)
+B = 5.13 +/- 0.019
+V = 5.24 +/- 0.017
 J = 5.418 +/- 0.029 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 5.444 +/- 0.038
 K = 5.463 +/- 0.023
@@ -13,3 +13,4 @@ WISE3 = 5.586 +/- 0.015
 WISE4 = 5.548 +/- 0.040
 corfac_spex_SXD = 0.976
 corfac_spex_LXD = None
+spex_mask = [(0.809,0.8103),(1.343,1.421),(1.799,1.949)]

--- a/DAT_files/hd091316.dat
+++ b/DAT_files/hd091316.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 91316 (IUE standard)
-V = 3.85 +/- 0.02 ; UBVRI ref = 1966CoLPL...4...99J
+V = 3.85 +/- 0.02 ; UBVRI ref = Johnson+1966 (1966CoLPL...4...99J, source 4133)
 U = 2.76 +/- 0.02
 B = 3.71 +/- 0.02
 R = 3.90 +/- 0.02
@@ -23,3 +23,4 @@ WISE4 = 4.051 +/- 0.025
 corfac_spex_SXD = 0.948
 LXD_man = True
 corfac_spex_LXD = 1.29
+spex_mask = [(1.348,1.415),(1.798,1.949),(2.515,2.53)]

--- a/DAT_files/hd156247.dat
+++ b/DAT_files/hd156247.dat
@@ -1,19 +1,21 @@
 # data file for observations of HD 156247
-V = 5.910 +/- 0.040
-B = 5.960 +/- 0.040
-U = 5.500 +/- 0.040
+V = 5.91 +/- 0.04 ; UBV ref = Valencic+2004 (2004ApJ...616..912V)
+B = 5.96 +/- 0.04
+U = 5.50 +/- 0.04
 J = 5.656 +/- 0.020 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 5.720 +/- 0.044
 K = 5.739 +/- 0.027
 IUE = IUE_Data/hd156247_iue.fits
 SpeX_SXD = SpeX_Data/hd156247_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd156247_LXD_spex.fits
-WISE1 = 5.923 +/- 0.108 ; WISE ref = IRSA AllWISE Source Catalog
-WISE2 = 5.793 +/- 0.044
+# WISE 1 and 2 seem off
+# WISE1 = 5.923 +/- 0.108 ; WISE ref = IRSA AllWISE Source Catalog
+# WISE2 = 5.793 +/- 0.044
 WISE3 = 5.935 +/- 0.015
 WISE4 = 5.700 +/- 0.041
 sptype = B3V ; sptype ref = Houk & Swift 1999 (1999MSS...C05....0H)
 uvsptype = B4IV ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 1.377
 LXD_man = True
-corfac_spex_LXD = 0.054
+corfac_spex_LXD = 0.0525
+spex_mask = [(0.804,0.805),(1.347,1.36),(1.798,1.953),(2.514,2.972)]

--- a/DAT_files/hd164794.dat
+++ b/DAT_files/hd164794.dat
@@ -1,6 +1,6 @@
 # data file for observations of HD 164794 (IUE standard)
-V = 5.97 +/- 0.02 ; UBVRI ref = 1966CoLPL...4...99J
-(B-V) =  0.00 +/- 0.02 
+V = 5.97 +/- 0.02 ; UBVRI ref = Johnson+1966 (1966CoLPL...4...99J, source 6736)
+(B-V) = 0.00 +/- 0.02 
 (U-B) = -0.89 +/- 0.02
 R = 5.72 +/- 0.02
 I = 5.70 +/- 0.02
@@ -21,6 +21,7 @@ IRAC4 = 5.757 +/- 0.027
 WISE1 = 5.879 +/- 0.062 ; WISE ref = IRSA AllWISE Source Catalog
 WISE2 = 5.647 +/- 0.024
 # IRSA catalog flags W3 and W4 as contaminated by a diffraction spike from a nearby bright star.
-corfac_spex_SXD = 0.883
+corfac_spex_SXD = 0.884
 LXD_man = True
 corfac_spex_LXD = 0.91
+spex_mask = [(1.347,1.419),(2.513,2.53)]

--- a/DAT_files/hd166734.dat
+++ b/DAT_files/hd166734.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 166734
-V = 8.420 +/- 0.01 ; UBV ref = 1956ApJS....2..389
+V = 8.42 +/- 0.01 ; UBV ref = Hiltner 1956 (1956ApJS....2..389H)
 (B-V) = 1.09 +/- 0.01
 (U-B) = -0.12 +/- 0.01
 J = 5.881 +/- 0.020 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
@@ -24,5 +24,7 @@ WISE4 = 4.174 +/- 0.032
 # corfac_irs = 0.949
 # corfac_irs_slope = 0.004
 # corfac_irs_zerowave = 7.480
-corfac_spex_SXD = 1.194
-corfac_spex_LXD = 2.279
+corfac_spex_SXD = 1.195
+LXD_man = True
+corfac_spex_LXD = 2.15
+spex_mask = [(0.809,0.81),(1.346,1.479),(1.775,1.993),(2.514,2.883)]

--- a/DAT_files/hd183143.dat
+++ b/DAT_files/hd183143.dat
@@ -1,19 +1,24 @@
 # data file for observations of HD 183143
-V = 6.840 +/- 0.010
-B = 8.080 +/- 0.010
-U = 8.170 +/- 0.010
-R = 5.74  +/- 0.010
-I = 4.79  +/- 0.020
+V = 6.86 +/- 0.01 ; UBVRI ref = Johnson 1965 (1965ApJ...141..923J)
+B = 8.08 +/- 0.01
+U = 8.25 +/- 0.01
+R = 5.74 +/- 0.01
+# I seems off
+# I = 4.79  +/- 0.020
 J = 4.13 +/- 0.03 ; JK ref = 1965ApJ...141..923J (no uncertainties, assume 0.03)
 K = 3.48 +/- 0.03
-L = 2.89  +/- 0.030
+# L seems off
+# L = 2.89  +/- 0.030
 SpeX_SXD = SpeX_Data/hd183143_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd183143_LXD_spex.fits
-WISE1 = 3.307 +/- 0.478 ; WISE ref = IRSA AllWISE Source Catalog
-WISE2 = 2.817 +/- 0.483
+# WISE 1 has a very large error bar
+# WISE1 = 3.307 +/- 0.478 ; WISE ref = IRSA AllWISE Source Catalog
+# WISE 2 seems off
+# WISE2 = 2.817 +/- 0.483
 WISE3 = 3.053 +/- 0.012
 WISE4 = 2.768 +/- 0.021
 sptype = B7Ia ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
-corfac_spex_SXD = 0.593
+corfac_spex_SXD = 0.591
 LXD_man = True
-corfac_spex_LXD = 0.62
+corfac_spex_LXD = 0.615
+spex_mask = [(2.87,2.879),(5.24,5.35)]

--- a/DAT_files/hd185418.dat
+++ b/DAT_files/hd185418.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 185418
-V = 7.450 +/- 0.010
-B = 7.670 +/- 0.010
-U = 7.000 +/- 0.010
+V = 7.45 +/- 0.01 ; UBV ref = Valencic+2004 (2004ApJ...616..912V)
+B = 7.67 +/- 0.01
+U = 7.00 +/- 0.01
 J = 7.033 +/- 0.023 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 7.091 +/- 0.040
 K = 7.086 +/- 0.023
@@ -18,4 +18,4 @@ uvsptype = B0.5III ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 1.002
 LXD_man = True
 corfac_spex_LXD = 0.79
-spex_mask = [(3.55,4.02)]
+spex_mask = [(1.347,1.36),(1.797,1.956),(3.568,5.2)]

--- a/DAT_files/hd188209.dat
+++ b/DAT_files/hd188209.dat
@@ -1,5 +1,5 @@
 # data file for observations of hd188209
-V = 5.62 +/- 0.02     # UBVRI ref = 1966CoLPL...4...99J
+V = 5.62 +/- 0.02 ; UBVRI ref = Johnson+1966 (1966CoLPL...4...99J, source 7589)
 (B-V) = -0.07 +/- 0.02
 (U-B) = -0.97 +/- 0.02
 R = 5.52 +/- 0.02
@@ -34,3 +34,4 @@ corfac_irs = 0.95
 corfac_spex_SXD = 0.603
 LXD_man = True
 corfac_spex_LXD = 1.015
+spex_mask = [(1.341,1.453),(1.798,1.81),(2.87,2.908),(5.24,5.34)]

--- a/DAT_files/hd192660.dat
+++ b/DAT_files/hd192660.dat
@@ -1,11 +1,9 @@
 # data file for observations of HD 192660
-V = 7.38  +/- 0.030  ; UBVRI ref = 1983ApJS...52....7F
+V = 7.38 +/- 0.03 ; UBVRI ref = Fernie 1983 (1983ApJS...52....7F)
 (U-V) = 0.45 +/- 0.03
 (B-V) = 0.67 +/- 0.03
 (V-R) = 0.58 +/- 0.03
 (V-I) = 1.03 +/- 0.03
-B = 8.170 +/- 0.010
-U = 7.810 +/- 0.010
 J = 6.151 +/- 0.018 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 6.004 +/- 0.017
 K = 5.909 +/- 0.016
@@ -18,13 +16,15 @@ sptype = B0Ia ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
 uvsptype = B0Ia ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_irs_maxwave = 32.0
 MIPS24 = 4.77E+01 +/- 1.07E+00 mJy
-IRAC1 = 1.38E+03 +/- 2.78E+01 mJy
-IRAC2 = 9.13E+02 +/- 1.86E+01 mJy
+# IRAC 1 and 2 seem off
+# IRAC1 = 1.38E+03 +/- 2.78E+01 mJy
+# IRAC2 = 9.13E+02 +/- 1.86E+01 mJy
 IRAC3 = 6.58E+02 +/- 1.51E+01 mJy
 IRAC4 = 3.44E+02 +/- 7.26E+00 mJy
 IRS15 = 1.01E+02 +/- 2.04E+00 mJy
 WISE1 = 5.813 +/- 0.136 ; WISE ref = IRSA AllWISE Source Catalog
-WISE2 = 5.647 +/- 0.051
+# WISE 2 seems off
+# WISE2 = 5.647 +/- 0.051
 WISE3 = 5.675 +/- 0.016
 WISE4 = 5.469 +/- 0.064 
 # corfac_irs = 0.982
@@ -33,3 +33,4 @@ WISE4 = 5.469 +/- 0.064
 corfac_spex_SXD = 1.415
 LXD_man = True
 corfac_spex_LXD = 1.1
+spex_mask = [(2.87,2.905),(4.012,4.02)]

--- a/DAT_files/hd204172.dat
+++ b/DAT_files/hd204172.dat
@@ -1,5 +1,5 @@
 # data file for observations of hd204172
-V = 5.93 +/- 0.020    # UBVRI ref = 1977AJ.....82..431L
+V = 5.93 +/- 0.020 ; UBV ref = Lutz & Lutz 1977 (1977AJ.....82..431L, HR 8209A)
 (B-V) = -0.08 +/- 0.014
 (U-B) = -0.93 +/- 0.018
 J = 6.085 +/- 0.021 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
@@ -28,4 +28,5 @@ corfac_irs_slope = -0.001
 corfac_irs_zerowave = 7.478
 corfac_spex_SXD = 0.978
 LXD_man = True
-corfac_spex_LXD = 0.92
+corfac_spex_LXD = 0.925
+spex_mask = [(0.804,0.8047),(2.87,2.907),(5.24,5.34)]

--- a/DAT_files/hd204827.dat
+++ b/DAT_files/hd204827.dat
@@ -1,8 +1,9 @@
 # data file for observations of HD 204827
-V = 7.950 +/- 0.010  ; UBV ref = 1956ApJS....2..389H
+V = 7.95 +/- 0.01 ; UBV ref = Hiltner 1956 (1956ApJS....2..389H)
 (B-V) = 0.81 +/- 0.01
 (U-B) = -0.15 +/- 0.01
 J = 6.472 +/- 0.020 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
+# 2MASS H suffers from diffraction spike confusion
 H = 6.356 +/- 0.021
 K = 6.319 +/- 0.016
 IUE = IUE_Data/hd204827_iue.fits
@@ -22,12 +23,14 @@ IRAC3 = 3.88E+02 +/- 1.06E+01 mJy
 IRAC4 = 1.84E+02 +/- 4.35E+00 mJy
 IRS15 = 4.73E+01 +/- 9.59E-01 mJy
 WISE1 = 6.252 +/- 0.071 ; WISE ref = IRSA AllWISE Source Catalog
-WISE2 = 6.084 +/- 0.022
+# WISE 2 seems off
+# WISE2 = 6.084 +/- 0.022
 WISE3 = 6.319 +/- 0.014
 WISE4 = 6.350 +/- 0.055
 # corfac_irs = 0.913
 # corfac_irs_slope = 0.006
 # corfac_irs_zerowave = 7.456
-corfac_spex_SXD = 1.136
+corfac_spex_SXD = 1.135
 LXD_man = True
-corfac_spex_LXD = .99
+corfac_spex_LXD = 0.99
+spex_mask = [(1.343,1.42),(1.798,1.966),(2.514,2.89),(4,4.02),(5.25,5.28)]

--- a/DAT_files/hd206773.dat
+++ b/DAT_files/hd206773.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 206773
-V = 6.79 +/- 0.016  ; UBV ref = 1976PASP...88..865G
+V = 6.79 +/- 0.016 ; UBV ref = Garrison & Kormendy 1976 (1976PASP...88..865G, BD+57d2374)
 (B-V) = 0.22 +/- 0.016
 (U-B) = -0.84 +/- 0.06
 J = 6.072 +/- 0.024 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
@@ -13,13 +13,15 @@ IRS = IRS_Data/hd206773_irs.fits
 sptype = B0V:pe ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
 uvsptype = B0Ia ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 MIPS24 = 1.23E+02 +/- 2.69E+00 mJy
-IRAC1 = 1.15E+03 +/- 2.32E+01 mJy
-IRAC2 = 8.30E+02 +/- 1.69E+01 mJy
+# IRAC 1 and 2 seem off
+# IRAC1 = 1.15E+03 +/- 2.32E+01 mJy
+# IRAC2 = 8.30E+02 +/- 1.69E+01 mJy
 IRAC3 = 6.45E+02 +/- 1.48E+01 mJy
 IRAC4 = 3.92E+02 +/- 8.20E+00 mJy
 IRS15 = 2.04E+02 +/- 4.19E+00 mJy
-WISE1 = 6.415 +/- 0.082 ; WISE ref = IRSA AllWISE Source Catalog
-WISE2 = 6.104 +/- 0.033
+# WISE 1 and 2 seem off
+# WISE1 = 6.415 +/- 0.082 ; WISE ref = IRSA AllWISE Source Catalog
+# WISE2 = 6.104 +/- 0.033
 WISE3 = 5.791 +/- 0.016
 WISE4 = 4.192 +/- 0.032
 # corfac_irs = 0.834
@@ -27,4 +29,5 @@ WISE4 = 4.192 +/- 0.032
 # corfac_irs_zerowave = 7.500
 corfac_spex_SXD = 1.367
 LXD_man = True
-corfac_spex_LXD = 1.49
+corfac_spex_LXD = 1.5
+spex_mask = [(1.94,1.948),(2.514,2.877)]

--- a/DAT_files/hd214680.dat
+++ b/DAT_files/hd214680.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 214680 (IUE standard)
-V = 4.88 +/- 0.02   ; UBV ref = 1966CoLPL...4...99J
+V = 4.88 +/- 0.02 ; UBVRI ref = Johnson+1966 (1966CoLPL...4...99J, source 8622)
 (B-V) = -0.20 +/- 0.02
-(U-B) = -1.04 +/- 0.02
+(U-B) = -1.05 +/- 0.02
 R = 4.97 +/- 0.02
 I = 5.18 +/- 0.02
 J = 5.303 +/- 0.037 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
@@ -34,4 +34,5 @@ WISE4 = 5.701 +/- 0.037
 # corfac_irs_zerowave = 7.460
 corfac_spex_SXD = 0.867
 LXD_man = True
-corfac_spex_LXD = .935
+corfac_spex_LXD = 0.935
+spex_mask = [(0.804,0.8047),(1.34,1.36),(1.803,1.95),(2.515,2.877),(5.17,5.2)]

--- a/DAT_files/hd229238.dat
+++ b/DAT_files/hd229238.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 229238
-V = 8.88 +/- 0.01  ; UBV ref = 1956ApJS....2..389
+V = 8.88 +/- 0.01 ; UBV ref = Hiltner 1956 (1956ApJS....2..389H)
 (B-V) = 0.90 +/- 0.01
 (U-B) = -0.06 +/- 0.01
 J = 7.015 +/- 0.023 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
@@ -28,3 +28,4 @@ corfac_irs_zerowave = 7.444
 corfac_spex_SXD = 1.246
 LXD_man = True
 corfac_spex_LXD = 0.96
+spex_mask = [(2.87,2.966),(4.012,4.02)]

--- a/DAT_files/hd283809.dat
+++ b/DAT_files/hd283809.dat
@@ -1,5 +1,5 @@
 # data file for observations of HD 283809
-V = 10.72 +/- 0.017  ; UBVRI ref = 1980SvAL....6..397S
+V = 10.72 +/- 0.017 ; UBVRI ref = Slutskij, Stalbovskij & Shevchenko 1980 (1980SvAL....6..397S)
 (B-V) = 1.42 +/- 0.030
 (U-B) = 0.49 +/- 0.019
 (V-R) = 1.44 +/- 0.024
@@ -28,3 +28,4 @@ WISE4 = 5.880 +/- 0.052
 corfac_spex_SXD = 1.304
 LXD_man = True
 corfac_spex_LXD = 1.09
+spex_mask = [(1.94,1.95),(4.012,4.6),(5.3,5.4)]

--- a/DAT_files/hd294264.dat
+++ b/DAT_files/hd294264.dat
@@ -1,7 +1,7 @@
 # data file for observations of HD 294264
-V = 9.470 +/- 0.010
-B = 9.830 +/- 0.010
-U = 9.420 +/- 0.010
+V = 9.47 +/- 0.01 ; UBV ref = Valencic+2004 (2004ApJ...616..912V)
+B = 9.83 +/- 0.01
+U = 9.42 +/- 0.01
 J = 8.086 +/- 0.029 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 7.744 +/- 0.034
 K = 7.582 +/- 0.033
@@ -13,10 +13,12 @@ uvsptype = B3IV ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 IRAC3 = 1.3050E+02 +/- 6.3350E-02 mJy ; IRAC ref = IRSA SEIP Source List
 IRAC4 = 8.0270E+01 +/- 4.2560E-02 mJy
 WISE1 = 7.448 +/- 0.036 ; WISE ref = IRSA AllWISE Source Catalog
-WISE2 = 7.424 +/- 0.021
+# WISE 2 seems off
+# WISE2 = 7.424 +/- 0.021
 # WISE3 and WISE4 data points seem to be too high
 # WISE3 = 6.437 +/- 0.069
 # WISE4 = 2.547 +/- 0.072 
 corfac_spex_SXD = 0.830
 LXD_man = True
-corfac_spex_LXD = 1.13
+corfac_spex_LXD = 1.125
+spex_mask = [(1.349,1.36),(1.94,1.951),(2.87,2.974)]


### PR DESCRIPTION
I made the following changes for the stars in the NIR extinction paper sample:
- Updated some of the UBVRI photometry
- Updated the references for the UBVRI photometry
- Updated the references for the spectral types
- Added SpeX masks for regions in the SpeX spectra that need to be excluded
- Commented out some IRAC and WISE photometry that seems to be far from the SpeX spectra
