### PR TITLE
Update to F19 .dat files

### DIFF
--- a/DAT_files/bd+44d1080.dat
+++ b/DAT_files/bd+44d1080.dat
@@ -5,6 +5,7 @@ U = 0.000 +/- 0.000
 J = 7.600 +/- 0.030
 H = 7.480 +/- 0.020
 K = 7.330 +/- 0.020
+STIS_Opt = STIS_Data/bd+44d1080_stis_Opt.fits
 IUE = IUE_Data/bd+44d1080_iue.fits
-sptype = B5V
+sptype = B6III ; ref = 2019ApJ...886..108F
 uvsptype = B5V

--- a/DAT_files/bd+56d517.dat
+++ b/DAT_files/bd+56d517.dat
@@ -5,6 +5,7 @@ U = 10.260 +/- 0.030
 J = 9.840 +/- 0.030
 H = 9.810 +/- 0.030
 K = 9.770 +/- 0.020
+STIS_Opt = STIS_Data/bd+56d517_stis_Opt.fits
 IUE = IUE_Data/bd+56d517_iue.fits
-sptype = B1.5V
+sptype = B1.5V ; ref = 2019ApJ...886..108F
 uvsptype = B1V

--- a/DAT_files/bd+56d518.dat
+++ b/DAT_files/bd+56d518.dat
@@ -5,6 +5,7 @@ U = 10.530 +/- 0.030
 J = 9.990 +/- 0.030
 H = 9.930 +/- 0.030
 K = 9.900 +/- 0.020
+STIS_Opt = STIS_Data/bd+56d518_stis_Opt.fits
 IUE = IUE_Data/bd+56d518_iue.fits
-sptype = B1.5V
+sptype = B1.5V ; ref = 2019ApJ...886..108F
 uvsptype = B1V

--- a/DAT_files/bd+56d576.dat
+++ b/DAT_files/bd+56d576.dat
@@ -5,6 +5,7 @@ U = 9.140 +/- 0.010
 J = 8.750 +/- 0.020
 H = 8.760 +/- 0.030
 K = 8.710 +/- 0.020
+STIS_Opt = STIS_Data/bd+56d576_stis_Opt.fits
 IUE = IUE_Data/bd+56d576_iue.fits
-sptype = B2III
+sptype = B2III ; ref = 2019ApJ...886..108F
 uvsptype = B1.5III

--- a/DAT_files/bd+69d1231.dat
+++ b/DAT_files/bd+69d1231.dat
@@ -1,0 +1,9 @@
+# data file for observations of BD+69 1231
+B = 9.41 +/- 0.03 ; BV ref = https://simbad.cds.unistra.fr/simbad/i, default uncertainty used due to no ref uncertainty
+V = 9.29 +/- 0.03
+G = 9.244973 +/- 0.002765 ; ref = 2020yCat.1350....0G
+J = 8.896 +/- 0.027 ; JHK ref = 2003yCat.2246....0C
+H = 8.878 +/- 0.03
+K = 8.818 +/- 0.019
+STIS_Opt = STIS_Data/bd+69d1231_stis_Opt.fits
+sptype = B9.5V ; ref = 2019ApJ...886..108F

--- a/DAT_files/bd_71d92.dat
+++ b/DAT_files/bd_71d92.dat
@@ -1,0 +1,5 @@
+# data file for observations of BD+71 92
+B = 10.44 +/- 0.05 ; BV ref = https://simbad.cds.unistra.fr/simbad/, default uncertainty used due to no reference uncertainty
+V = 10.28 +/- 0.05
+G = 10.251820 +/- 0.002769 ; ref = 2020yCat.1350....0G
+STIS_Opt = STIS_Data/bd_71d92_stis_Opt.fits 

--- a/DAT_files/cpd-57d3523.dat
+++ b/DAT_files/cpd-57d3523.dat
@@ -1,0 +1,6 @@
+# data file for observations of CPD-57 3523
+U = 7.19 +/- 0.03 ; ref = 2003AJ....125.2531R, default uncertainty 0.03 used due to no reference
+B = 8.05 +/- 0.03 ; BV ref = https://simbad.u-strasbg.fr/simbad/sim-basic?Ident=CPD-57+3523&submit=SIMBAD+search
+V = 8.03 +/- 0.03
+STIS_Opt = STIS_Data/cpd-57d3523_stis_Opt.fits
+sptype = B1III ; ref = 2019ApJ...886..108F

--- a/DAT_files/cpd-59d2591.dat
+++ b/DAT_files/cpd-59d2591.dat
@@ -1,0 +1,11 @@
+# data file for observations of CPD-59 2591
+U = 10.726 +/- 0.03 ; UBVI ref = 2012AJ....143...41H, default uncertainty of 0.03 added due to no ref uncertainty
+B = 11.312 +/- 0.03
+V = 10.851 +/- 0.008
+G = 10.627538 +/- 0.002788 ; ref = 2020yCat.1350....0G
+I = 9.975
+J = 9.384 +/- 0.021 ; JHK ref = 2003yCat.2246....0C
+H = 9.142 +/- 0.021
+K = 9.007 +/- 0.020
+STIS_Opt = STIS_Data/cpd-59d2591_stis_Opt.fits
+sptype = O8.5V+BO.5 ; ref = 2014ApJS..211...10S

--- a/DAT_files/gsc03712-01870.dat
+++ b/DAT_files/gsc03712-01870.dat
@@ -1,0 +1,10 @@
+# data file for observations of GSC03712-01870
+V = 13.02 +/- 0.03
+B = 13.73 +/- 0.03 ; BV ref = https://simbad.cds.unistra.fr/simbad/, default uncertainty of 0.03 due to no reference
+U = 13.32 +/- 0.03 ; ref = 2003AJ....125.2531R
+J = 11.448 +/- 0.024 ; JHK ref = 2003yCat.2246....0C
+H = 11.29 +/- 0.03
+K = 11.160 +/- 0.024
+G = 12.784429 +/- 0.002773 ; ref = 2020yCat.1350....0G
+STIS_Opt = STIS_Data/gsc03712-01870_stis_Opt.fits
+sptype = O5+ ; ref = 2019ApJ...886..108F

--- a/DAT_files/hd014250.dat
+++ b/DAT_files/hd014250.dat
@@ -5,6 +5,7 @@ U = 8.74 +/- 0.01
 J = 8.274 +/- 0.030 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 8.225 +/- 0.044
 K = 8.209 +/- 0.029
+STIS_Opt = STIS_Data/hd14250_stis_Opt.fits
 IUE = IUE_Data/hd014250_iue.fits
 FUSE = FUSE_Data/hd014250_fuse.fits
 SpeX_SXD = SpeX_Data/hd014250_SXD_spex.fits
@@ -21,7 +22,7 @@ MIPS24 = 3.382E+00 +/- 2.304E-02 mJy
 WISE2 = 8.258 +/- 0.021
 WISE3 = 8.299 +/- 0.024
 WISE4 = 7.883 +/- 0.153
-sptype = B0.5V:n ; sptype ref = Morgan, Code & Whitford 1955 (1955ApJS....2...41M)
+sptype = B1III ; ref = 2019ApJ...886..108F
 uvsptype = B1.5III ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 corfac_spex_SXD = 0.152
 LXD_man = True

--- a/DAT_files/hd014321.dat
+++ b/DAT_files/hd014321.dat
@@ -5,6 +5,7 @@ U = 8.980 +/- 0.010
 J = 8.650 +/- 0.020
 H = 8.650 +/- 0.050
 K = 8.610 +/- 0.020
+STIS_Opt = STIS_Data/hd14321_stis_Opt.fits
 IUE = IUE_Data/hd014321_iue.fits
-sptype = B1IV
+sptype = B1IV ; ref = 2019ApJ...886..108F
 uvsptype = B1.5V

--- a/DAT_files/hd017443.dat
+++ b/DAT_files/hd017443.dat
@@ -1,0 +1,9 @@
+# data file for observations of HD 17443
+B = 9.04 +/- 0.03 ; BV ref = https://simbad.cds.unistra.fr/simbad/, default uncertainty 0.03 used
+V = 8.75 +/- 0.03
+G = 8.714512 +/- 0.002762 ; ref = 2022yCat.1355....0G
+J = 8.131 +/- 0.030 ; JHK ref = 2003yCat.2246....0C
+H = 8.084 +/- 0.033
+K = 7.994 +/- 0.020
+STIS_Opt = STIS_Data/hd17443_stis_Opt.fits
+sptype = B9V ; ref = 2019ApJ...886..108F

--- a/DAT_files/hd018352.dat
+++ b/DAT_files/hd018352.dat
@@ -5,6 +5,7 @@ U = 6.400 +/- 0.010
 J = 6.360 +/- 0.020
 H = 6.450 +/- 0.040
 K = 6.380 +/- 0.020
+STIS_Opt = STIS_Data/hd18352_stis_Opt.fits
 IUE = IUE_Data/hd018352_iue.fits
-sptype = B1V
+sptype = B1V ; ref = 2019ApJ...886..108F
 uvsptype = B2IV

--- a/DAT_files/hd027778.dat
+++ b/DAT_files/hd027778.dat
@@ -8,5 +8,5 @@ K = 5.930 +/- 0.020
 IUE = IUE_Data/hd027778_iue.fits
 FUSE = FUSE_Data/hd027778_fuse.fits
 STIS_Opt = STIS_Data/hd27778_stis_Opt.fits
-sptype = B3V
+sptype = B3V ; ref = 2019ApJ...886..108F
 uvsptype = B5V

--- a/DAT_files/hd029647.dat
+++ b/DAT_files/hd029647.dat
@@ -7,10 +7,11 @@ V = 8.31 +/- 0.017 ; UBVRI ref = Slutskij, Stalbovskij & Shevchenko 1980 (1980Sv
 J = 5.960 +/- 0.030 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 5.593 +/- 0.021
 K = 5.363 +/- 0.020
+STIS_Opt = STIS_Data/hd29647_stis_Opt.fits
 IUE = IUE_Data/hd029647_iue.fits
 SpeX_SXD = SpeX_Data/hd029647_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd029647_LXD_spex.fits
-sptype = B7IV ; sptype ref = Murakawa, Tamura & Nagata 2000 (2000ApJS..128..603M)
+sptype = B8III ; ref = 2019ApJ...886..108F
 uvsptype = B8III ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 IRS = IRS_Data/hd029647_irs.fits
 MIPS24 = 6.76E+01 +/- 1.89E+00 mJy

--- a/DAT_files/hd030122.dat
+++ b/DAT_files/hd030122.dat
@@ -1,0 +1,8 @@
+# data file for observations of HD 30122
+B = 6.386 +/- 0.015 ; BV ref = 2000A&A...355L..27H
+V = 6.329 +/- 0.010
+J = 6.075 +/- 0.018 ; JHK ref = 2022yCat.1355....0G
+H = 6.106 +/- 0.021
+K = 6.099 +/- 0.018
+STIS_Opt = STIS_Data/hd30122_stis_Opt.fits
+sptype = B5III ; ref = 2019ApJ...886..108F

--- a/DAT_files/hd030675.dat
+++ b/DAT_files/hd030675.dat
@@ -5,6 +5,7 @@ U = 7.610 +/- 0.010
 J = 6.720 +/- 0.020
 H = 6.690 +/- 0.030
 K = 6.630 +/- 0.020
+STIS_Opt = STIS_Data/hd30675_stis_Opt.fits
 IUE = IUE_Data/hd030675_iue.fits
-sptype = B3V
+sptype = B3V ; ref = 2019ApJ...886..108F
 uvsptype = B5V

--- a/DAT_files/hd037061.dat
+++ b/DAT_files/hd037061.dat
@@ -6,10 +6,11 @@ U = 6.40 +/- 0.01
 J = 5.752 +/- 0.027 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 5.588 +/- 0.040
 K = 5.490 +/- 0.021
+STIS_Opt = STIS_Data/hd37061_stis_Opt.fits
 IUE = IUE_Data/hd037061_iue.fits
 SpeX_SXD = SpeX_Data/hd037061_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd037061_LXD_spex.fits
-sptype = B1V ; sptype ref = Sharpless 1952 (1952ApJ...116..251S)
+sptype = B0.5V ; ref = 2019ApJ...886..108F
 uvsptype = B0V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 # There seems to be a problem with the WISE data, probably wrong source.
 # WISE have extended source contamination

--- a/DAT_files/hd038087.dat
+++ b/DAT_files/hd038087.dat
@@ -6,11 +6,12 @@ U = 7.97 +/- 0.01
 J = 7.588 +/- 0.024 ; JHK ref = IRSA 2MASS All-Sky Point Source Catalog
 H = 7.386 +/- 0.042
 K = 7.252 +/- 0.023
+STIS_Opt = STIS_Data/hd38087_stis_Opt.fits
 IUE = IUE_Data/hd038087_iue.fits
 FUSE = FUSE_Data/hd038087_fuse.fits
 SpeX_SXD = SpeX_Data/hd038087_SXD_spex.fits
 SpeX_LXD = SpeX_Data/hd038087_LXD_spex.fits
-sptype = B3II ; sptype ref = Houk & Swift 1999 (1999MSS...C05....0H)
+sptype = B5V ; ref = 2019ApJ...886..108F
 uvsptype = B4V ; uvsptype ref = Valencic+2004 (2004ApJ...616..912V)
 IRAC3 = 1.4440E+02 +/- 7.0390E-02 mJy ; IRAC ref = IRSA SEIP Source List
 IRAC4 = 8.1580E+01 +/- 3.3750E-02 mJy

--- a/DAT_files/hd040893.dat
+++ b/DAT_files/hd040893.dat
@@ -5,6 +5,7 @@ U = 8.280 +/- 0.010
 J = 8.610 +/- 0.020
 H = 8.640 +/- 0.040
 K = 8.630 +/- 0.020
+STIS_Opt = STIS_Data/hd40893_stis_Opt.fits
 IUE = IUE_Data/hd040893_iue.fits
-sptype = B1IV
+sptype = B0IV ; ref = 2019ApJ...886..108F
 uvsptype = O7V

--- a/DAT_files/hd046106.dat
+++ b/DAT_files/hd046106.dat
@@ -5,6 +5,7 @@ U = 7.300 +/- 0.010
 J = 7.610 +/- 0.020
 H = 7.590 +/- 0.030
 K = 7.620 +/- 0.020
+STIS_Opt = STIS_Data/hd46106_stis_Opt.fits
 IUE = IUE_Data/hd046106_iue.fits
-sptype = B1V
+sptype = B1V ; ref = 2019ApJ...886..108F
 uvsptype = B0.5V

--- a/DAT_files/hd046660.dat
+++ b/DAT_files/hd046660.dat
@@ -5,6 +5,7 @@ U = 7.740 +/- 0.010
 J = 7.390 +/- 0.020
 H = 7.380 +/- 0.040
 K = 7.270 +/- 0.010
+STIS_Opt = STIS_Data/hd46660_stis_Opt.fits
 IUE = IUE_Data/hd046660_iue.fits
-sptype = B1V
+sptype = B1V ; ref = 2019ApJ...886..108F
 uvsptype = B1.5V

--- a/DAT_files/hd054439.dat
+++ b/DAT_files/hd054439.dat
@@ -5,6 +5,7 @@ U = 6.980 +/- 0.010
 J = 7.600 +/- 0.030
 H = 7.670 +/- 0.040
 K = 7.720 +/- 0.030
+STIS_Opt = STIS_Data/hd54439_stis_Opt.fits
 IUE = IUE_Data/hd054439_iue.fits
-sptype = B2III
+sptype = B2IIIn ; ref = 2019ApJ...886..108F
 uvsptype = B1.5V

--- a/DAT_files/hd062542.dat
+++ b/DAT_files/hd062542.dat
@@ -4,7 +4,8 @@ B = 8.210 +/- 0.020
 J = 7.580 +/- 0.020
 H = 7.580 +/- 0.030
 K = 7.560 +/- 0.020
+STIS_Opt = STIS_Data/hd62542_stis_Opt.fits
 IUE = IUE_Data/hd062542_iue.fits
 FUSE = FUSE_Data/hd062542_fuse.fits
-sptype = B3V
+sptype = B5V ; ref = 2019ApJ...886..108F
 uvsptype = B4V

--- a/DAT_files/hd068633.dat
+++ b/DAT_files/hd068633.dat
@@ -5,6 +5,7 @@ U = 7.940 +/- 0.040
 J = 7.060 +/- 0.020
 H = 6.970 +/- 0.040
 K = 6.910 +/- 0.020
+STIS_Opt = STIS_Data/hd68633_stis_Opt.fits
 IUE = IUE_Data/hd068633_iue.fits
-sptype = B5V
+sptype = B5V ; ref = 2019ApJ...886..108F
 uvsptype = B2.5III

--- a/DAT_files/hd070614.dat
+++ b/DAT_files/hd070614.dat
@@ -5,6 +5,7 @@ U = 9.480 +/- 0.020
 J = 8.120 +/- 0.030
 H = 8.030 +/- 0.060
 K = 7.900 +/- 0.020
+STIS_Opt = STIS_Data/hd70614_stis_Opt.fits
 IUE = IUE_Data/hd070614_iue.fits
-sptype = B6V
+sptype = B6 ; ref = 2019ApJ...886..108F
 uvsptype = B4IV

--- a/DAT_files/hd091983.dat
+++ b/DAT_files/hd091983.dat
@@ -5,9 +5,10 @@ U = 7.790 +/- 0.030
 J = 8.460 +/- 0.020
 H = 8.530 +/- 0.060
 K = 8.540 +/- 0.020
+STIS_Opt = STIS_Data/hd91983_stis_Opt.fits
 IUE = IUE_Data/hd091983_iue.fits
 FUSE = FUSE_Data/hd091983_fuse.fits
-sptype = O9.5Ib
+sptype = B1III ; ref = 2019ApJ...886..108F
 uvsptype = B1.5III
 dered_RV = 3.1
 dered_RV_unc = 0.23

--- a/DAT_files/hd092044.dat
+++ b/DAT_files/hd092044.dat
@@ -5,6 +5,7 @@ U = 7.680 +/- 0.020
 J = 7.840 +/- 0.020
 H = 7.840 +/- 0.050
 K = 7.750 +/- 0.020
+STIS_Opt = STIS_Data/hd92044_stis_Opt.fits
 IUE = IUE_Data/hd092044_iue.fits
-sptype = B1II
+sptype = B0.5II ; ref = 2019ApJ...886..108F
 uvsptype = B1.5III

--- a/DAT_files/hd093028.dat
+++ b/DAT_files/hd093028.dat
@@ -5,9 +5,10 @@ U = 7.350 +/- 0.020
 J = 8.470 +/- 0.020
 H = 8.530 +/- 0.040
 K = 8.610 +/- 0.020
+STIS_Opt = STIS_Data/hd93028_stis_Opt.fits
 IUE = IUE_Data/hd093028_iue.fits
 FUSE = FUSE_Data/hd093028_fuse.fits
-sptype = O8V
+sptype = O9V ; ref = 2019ApJ...886..108F
 uvsptype = O9.5IV
 dered_RV = 3.2
 dered_RV_unc = 0.48

--- a/DAT_files/hd093222.dat
+++ b/DAT_files/hd093222.dat
@@ -5,7 +5,8 @@ U = 7.270 +/- 0.040
 J = 7.590 +/- 0.020
 H = 7.500 +/- 0.030
 K = 7.440 +/- 0.020
+STIS_Opt = STIS_Data/hd93222_stis_Opt.fits
 IUE = IUE_Data/hd093222_iue.fits
 FUSE = FUSE_Data/hd093222_fuse.fits
-sptype = O8V
+sptype = O7III((f)) ; ref = 2019ApJ...886..108F
 uvsptype = O7V

--- a/DAT_files/hd104705.dat
+++ b/DAT_files/hd104705.dat
@@ -5,9 +5,10 @@ U = 6.930 +/- 0.030
 J = 7.740 +/- 0.020
 H = 7.710 +/- 0.030
 K = 7.670 +/- 0.020
+STIS_Opt = STIS_Data/hd104705_stis_Opt.fits
 IUE = IUE_Data/hd104705_iue.fits
 FUSE = FUSE_Data/hd104705_fuse.fits
-sptype = B0III
+sptype = B0.5III ; ref = 2019ApJ...886..108F
 uvsptype = B0.5Ia
 dered_RV = 3.31
 dered_RV_unc = 0.33

--- a/DAT_files/hd110946.dat
+++ b/DAT_files/hd110946.dat
@@ -5,6 +5,7 @@ U = 8.860 +/- 0.010
 J = 8.450 +/- 0.020
 H = 8.440 +/- 0.030
 K = 8.380 +/- 0.030
+STIS_Opt = STIS_Data/hd110946_stis_Opt.fits
 IUE = IUE_Data/hd110946_iue.fits
-sptype = B1III
+sptype = B1V: ; ref = 2019ApJ...886..108F
 uvsptype = B2III

--- a/DAT_files/hd112607.dat
+++ b/DAT_files/hd112607.dat
@@ -1,0 +1,10 @@
+# data file for observations of HD 112607
+U = 7.98 +/- 0.03 ; ref = 2003AJ....125.2531R, default uncertainty of 0.03 used due to no ref uncertainty
+B = 8.24 +/- 0.03 ; BV ref = https://simbad.cds.unistra.fr/simbad/, default uncertainty of 0.03 used due to no ref uncertainty
+V = 8.10 +/- 0.03
+G = 8.033070 +/- 0.002770 ; ref = 2020yCat.1350....0G
+J = 7.615 +/- 0.029 ; JHK ref = 2003yCat.2246....0C
+H = 7.585 +/- 0.027
+K = 7.562 +/- 0.026
+STIS_Opt = STIS_Data/hd112607_stis_Opt.fits
+sptype = B7/B8III ; ref = 2019ApJ...886..108F

--- a/DAT_files/hd142096.dat
+++ b/DAT_files/hd142096.dat
@@ -1,0 +1,9 @@
+# data file for observations of HD 142096
+U = 4.43 +/- 0.02 ; UBV ref = 2003AJ....125.2531R, default uncertainty 0.02 used
+B = 4.997 +/- 0.014
+V = 5.027 +/- 0.009
+J = 4.987 +/- 0.037
+H = 5.001 +/- 0.027 ; JHK ref = 2003yCat.2246....0C
+K = 4.903 +/- 0.021
+STIS_Opt = STIS_Data/hd142096_stis_Opt.fits
+sptype = B2.5V ; ref = 2019ApJ...886..108F

--- a/DAT_files/hd147196.dat
+++ b/DAT_files/hd147196.dat
@@ -1,0 +1,10 @@
+# data file for observations of HD 147196
+U = 7.04 +/- 0.03 ; UBV ref = 2002yCat.2237....0D, default uncertainty of 0.03 used due to no ref uncertainty
+B = 7.21 +/- 0.03
+V = 7.04 +/- 0.03
+G = 6.992032 +/- 0.002770 ; ref = 2020yCat.1350....0G
+J = 6.565 +/- 0.039 ; JHK ref = 2003yCat.2246....0C
+H = 6.506 +/- 0.029
+K = 6.418 +/- 0.021
+STIS_Opt = STIS_Data/hd147196_stis_Opt.fits
+sptype = B5V ; ref = 2019ApJ...886..108F

--- a/DAT_files/hd147889.dat
+++ b/DAT_files/hd147889.dat
@@ -1,12 +1,13 @@
 # data file for observations of HD 147889
 V = 7.920 +/- 0.010  ; UBV ref = 1973MNSSA..32..117C
-(B-V) = 0.83 +/- 0.010
-(U-B) = -0.17 +/- 0.010
+#(B-V) = 0.83 +/- 0.010
+#(U-B) = -0.17 +/- 0.010
 J = 5.344 +/- 0.020
 H = 4.938 +/- 0.076
 K = 4.582 +/- 0.017
+STIS_Opt = STIS_Data/hd147889_stis_Opt.fits
 IUE = IUE_Data/hd147889_iue.fits
-sptype = B2IV
+sptype = B2V ; ref = 2019ApJ...886..108F
 uvsptype = B2V
 IRS = IRS_Data/hd147889_irs.fits
 MIPS24 = 1.68E+02 +/- 3.96E+00 mJy

--- a/DAT_files/hd149452.dat
+++ b/DAT_files/hd149452.dat
@@ -5,8 +5,9 @@ U = 9.200 +/- 0.010
 J = 7.600 +/- 0.030
 H = 7.480 +/- 0.020
 K = 7.340 +/- 0.030
+STIS_Opt = STIS_Data/hd149452_stis_Opt.fits
 IUE = IUE_Data/hd149452_iue.fits
-sptype = O9V
+sptype = O8Vn((f)) ; ref = 2019ApJ...886..108F
 uvsptype = O9.5Ia
 IRAC1 = 7.308 +/- 0.044
 IRAC2 = 7.186 +/- 0.105

--- a/DAT_files/hd164073.dat
+++ b/DAT_files/hd164073.dat
@@ -5,6 +5,7 @@ U = 7.550 +/- 0.010
 J = 7.710 +/- 0.020
 H = 7.610 +/- 0.020
 K = 7.570 +/- 0.020
+STIS_Opt = STIS_Data/hd164073_stis_Opt.fits
 IUE = IUE_Data/hd164073_iue.fits
-sptype = B3III
+sptype = B3III/IV ; ref = 2019ApJ...886..108F
 uvsptype = B4III

--- a/DAT_files/hd172140.dat
+++ b/DAT_files/hd172140.dat
@@ -5,9 +5,10 @@ U = 9.020 +/- 0.010
 J = 10.130 +/- 0.020
 H = 10.190 +/- 0.020
 K = 10.230 +/- 0.020
+STIS_Opt = STIS_Data/hd172140_stis_Opt.fits
 IUE = IUE_Data/hd172140_iue.fits
 FUSE = FUSE_Data/hd172140_fuse.fits
-sptype = B0.5III
+sptype = B0.5III ; ref = 2019ApJ...886..108F
 uvsptype = B0.5III
 dered_RV = 2.34
 dered_RV_unc = 0.47

--- a/DAT_files/hd193322.dat
+++ b/DAT_files/hd193322.dat
@@ -5,6 +5,7 @@ U = 5.160 +/- 0.010
 J = 5.640 +/- 0.030
 H = 5.690 +/- 0.020
 K = 5.720 +/- 0.020
+STIS_Opt = STIS_Data/hd193322_stis_Opt.fits
 IUE = IUE_Data/hd193322_iue.fits
-sptype = O9V
+sptype = O9V:((n)) ; ref = 2019ApJ...886..108F
 uvsptype = O9.5IV

--- a/DAT_files/hd197512.dat
+++ b/DAT_files/hd197512.dat
@@ -5,6 +5,7 @@ U = 7.930 +/- 0.010
 J = 8.450 +/- 0.020
 H = 8.500 +/- 0.020
 K = 8.540 +/- 0.010
+STIS_Opt = STIS_Data/hd197512_stis_Opt.fits
 IUE = IUE_Data/hd197512_iue.fits
-sptype = B1V
+sptype = B1V ; ref = 2019ApJ...886..108F
 uvsptype = B1V

--- a/DAT_files/hd197702.dat
+++ b/DAT_files/hd197702.dat
@@ -10,9 +10,10 @@ K = 6.940 +/- 0.018
 #IRAC2 = 1.75E+02 +/- 5.31E-01 mJy
 #IRAC3 = 1.25E+02 +/- 1.30E+00 mJy
 #IRAC4 = 6.84E+01 +/- 4.14E-01 mJy
+STIS_Opt = STIS_Data/hd197702_stis_Opt.fits
 IUE = IUE_Data/hd197702_iue.fits
 IRS = IRS_Data/hd197702_irs.fits
-sptype = B1III
+sptype = B1III(n) ; ref = 2019ApJ...886..108F
 uvsptype = B2Ib
 MIPS24 = 2.18E+01 +/- 5.25E-01 mJy
 IRAC1 = 2.83E+02 +/- 5.67E+00 mJy

--- a/DAT_files/hd198781.dat
+++ b/DAT_files/hd198781.dat
@@ -5,7 +5,8 @@ U = 5.750 +/- 0.010
 J = 6.300 +/- 0.020
 H = 6.380 +/- 0.040
 K = 6.400 +/- 0.020
+STIS_Opt = STIS_Data/hd198781_stis_Opt.fits
 IUE = IUE_Data/hd198781_iue.fits
 FUSE = FUSE_Data/hd198781_fuse.fits
-sptype = B0.5V
+sptype = B0.5 ; ref = 2019ApJ...886..108F
 uvsptype = B0.5III

--- a/DAT_files/hd199216.dat
+++ b/DAT_files/hd199216.dat
@@ -5,6 +5,7 @@ U = 7.050 +/- 0.010
 J = 6.050 +/- 0.020
 H = 6.030 +/- 0.030
 K = 5.970 +/- 0.020
+STIS_Opt = STIS_Data/hd199216_stis_Opt.fits
 IUE = IUE_Data/hd199216_iue.fits
-sptype = B1II
+sptype = B1II ; ref = 2019ApJ...886..108F
 uvsptype = B2III

--- a/DAT_files/hd210072.dat
+++ b/DAT_files/hd210072.dat
@@ -1,0 +1,9 @@
+# data file for observations of HD 210072
+U = 7.6 +/- 0.02 ; ref = 2003AJ....125.2531R, default uncertainty 0.02 used
+B = 7.88 +/- 0.02 ; BV ref = https://simbad.u-strasbg.fr/simbad/sim-basic?Ident=HD+210072&submit=SIMBAD+search
+V = 7.64 +/- 0.02 ;
+J = 7.044 +/- 0.034 ; JHK ref = 2003yCat.2246....0C
+H = 7.016 +/- 0.049
+K = 6.985 +/- 0.023
+STIS_Opt = STIS_Data/hd210072_stis_Opt.fits
+sptype = B2V ; ref = 2019ApJ...886..108F

--- a/DAT_files/hd217086.dat
+++ b/DAT_files/hd217086.dat
@@ -5,6 +5,7 @@ U = 7.850 +/- 0.010
 J = 6.230 +/- 0.020
 H = 6.100 +/- 0.020
 K = 6.030 +/- 0.010
+STIS_Opt = STIS_Data/hd217086_stis_Opt.fits
 IUE = IUE_Data/hd217086_iue.fits
-sptype = O7V
+sptype = O7Vn ; ref = 2019ApJ...886..108F
 uvsptype = O5V

--- a/DAT_files/hd220057.dat
+++ b/DAT_files/hd220057.dat
@@ -5,7 +5,8 @@ U = 6.370 +/- 0.020
 J = 6.830 +/- 0.030
 H = 6.900 +/- 0.050
 K = 6.930 +/- 0.030
+STIS_Opt = STIS_Data/hd220057_stis_Opt.fits
 IUE = IUE_Data/hd220057_iue.fits
 FUSE = FUSE_Data/hd220057_fuse.fits
-sptype = B2IV
+sptype = B2IV ; ref = 2019ApJ...886..108F
 uvsptype = B3IV

--- a/DAT_files/hd228969.dat
+++ b/DAT_files/hd228969.dat
@@ -5,6 +5,7 @@ U = 10.020 +/- 0.010
 J = 7.980 +/- 0.020
 H = 7.800 +/- 0.030
 K = 0.000 +/- 0.000
+STIS_Opt = STIS_Data/hd228969_stis_Opt.fits
 IUE = IUE_Data/hd228969_iue.fits
-sptype = B2II
+sptype = B2II ; ref = 2019ApJ...886..108F
 uvsptype = B0III

--- a/DAT_files/hd236960.dat
+++ b/DAT_files/hd236960.dat
@@ -5,6 +5,7 @@ U = 9.700 +/- 0.010
 J = 8.840 +/- 0.030
 H = 8.830 +/- 0.030
 K = 8.700 +/- 0.020
+STIS_Opt = STIS_Data/hd236960_stis_Opt.fits
 IUE = IUE_Data/hd236960_iue.fits
-sptype = B0.5III
+sptype = B0.5III ; ref = 2019ApJ...886..108F
 uvsptype = B0.5III

--- a/DAT_files/hd239693.dat
+++ b/DAT_files/hd239693.dat
@@ -5,6 +5,7 @@ U = 9.360 +/- 0.010
 J = 9.040 +/- 0.030
 H = 9.060 +/- 0.030
 K = 9.060 +/- 0.020
+STIS_Opt = STIS_Data/hd239693_stis_Opt.fits
 IUE = IUE_Data/hd239693_iue.fits
-sptype = B5V
+sptype = B3V ; ref = 2019ApJ...886..108F
 uvsptype = B4IV

--- a/DAT_files/hd239722.dat
+++ b/DAT_files/hd239722.dat
@@ -5,6 +5,7 @@ U = 10.080 +/- 0.030
 J = 8.200 +/- 0.030
 H = 8.050 +/- 0.050
 K = 8.040 +/- 0.030
+STIS_Opt = STIS_Data/hd239722_stis_Opt.fits
 IUE = IUE_Data/hd239722_iue.fits
-sptype = B5V
+sptype = B2IV ; ref = 2019ApJ...886..108F
 uvsptype = B1V

--- a/DAT_files/hd239745.dat
+++ b/DAT_files/hd239745.dat
@@ -5,6 +5,7 @@ U = 8.600 +/- 0.030
 J = 8.350 +/- 0.020
 H = 8.340 +/- 0.040
 K = 8.350 +/- 0.040
+STIS_Opt = STIS_Data/hd239745_stis_Opt.fits
 IUE = IUE_Data/hd239745_iue.fits
-sptype = B5V
+sptype = B1V ; ref = 2019ApJ...886..108F
 uvsptype = B1.5V

--- a/DAT_files/hd282485.dat
+++ b/DAT_files/hd282485.dat
@@ -1,0 +1,9 @@
+# data file for observations of HD 282485
+B = 10.10 +/- 0.03 ; ref = https://simbad.cds.unistra.fr/simbad/, default uncertainy used due to no ref uncertainty
+V = 9.9 +/- 0.03; ref = 1954ArA.....1..425A, default uncertainy used due to no ref uncertainty
+G = 9.746779 +/- 0.002762 ; ref = 2020yCat.1350....0G
+J = 9.061 +/- 0.018 ; JHK ref = 2003yCat.2246....0C
+H = 9.012 +/- 0.040
+K = 8.956 +/- 0.017
+STIS_Opt = STIS_Data/hd282485_stis_Opt.fits
+sptype = B9V ; ref = 2019ApJ...886..108F

--- a/DAT_files/hd292167.dat
+++ b/DAT_files/hd292167.dat
@@ -5,6 +5,7 @@ U = 9.100 +/- 0.010
 J = 8.200 +/- 0.020
 H = 8.140 +/- 0.030
 K = 7.990 +/- 0.020
+STIS_Opt = STIS_Data/hd292167_stis_Opt.fits
 IUE = IUE_Data/hd292167_iue.fits
-sptype = O9III
+sptype = O9III ; ref = 2019ApJ...886..108F
 uvsptype = O9.5IV

--- a/DAT_files/vss-viii10.dat
+++ b/DAT_files/vss-viii10.dat
@@ -1,0 +1,5 @@
+# data file for observations of VSS VIII-10
+V = 10.71 +/- 0.05
+B = 10.07 +/- 0.05 ; ref = https://simbad.cds.unistra.fr/simbad/sim-basic?Ident=vss+viii-10&submit=SIMBAD+search, default uncertainty used due to no ref uncertainty
+STIS_Opt = STIS_Data/vss-viii10_stis_Opt.fits
+sptype = B1V ; ref = https://simbad.cds.unistra.fr/simbad/sim-basic?Ident=vss+viii-10&submit=SIMBAD+search


### PR DESCRIPTION
There are two commits: 
1. New .dat files have been added for stars from the F19 sample that were previously missing
2. Spectral type has been update, or the references have been updated to those found in the F19 paper. 