### PR TITLE
fixing IUE data for one star

### DIFF
--- a/MW/IUE_Data/hd093160_iue.fits
+++ b/MW/IUE_Data/hd093160_iue.fits
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:203c2d9b7253d41cd9aae9b0853f371710884f22eacfef3316c60ece2e0f2567
+oid sha256:0dd91a3f7cc3fcb7788e485e31c604847a5656c00bd54a29b727ed2770e512b0
 size 37440


### PR DESCRIPTION
One of the two SWP spectra was lower than expected based on the LWP and other SWP spectrum causing a non-physical jump.  Removed the "bad" observation.